### PR TITLE
Add edge properties and support for edge attributes

### DIFF
--- a/directed.go
+++ b/directed.go
@@ -34,14 +34,14 @@ func (d *directed[K, T]) Vertex(value T) {
 	d.vertices[hash] = value
 }
 
-func (d *directed[K, T]) Edge(source, target T, options ...func(*edgeProperties)) error {
+func (d *directed[K, T]) Edge(source, target T, options ...func(*EdgeProperties)) error {
 	sourceHash := d.hash(source)
 	targetHash := d.hash(target)
 
 	return d.EdgeByHashes(sourceHash, targetHash, options...)
 }
 
-func (d *directed[K, T]) EdgeByHashes(sourceHash, targetHash K, options ...func(*edgeProperties)) error {
+func (d *directed[K, T]) EdgeByHashes(sourceHash, targetHash K, options ...func(*EdgeProperties)) error {
 	source, ok := d.vertices[sourceHash]
 	if !ok {
 		return fmt.Errorf("could not find source vertex with hash %v", sourceHash)
@@ -70,13 +70,13 @@ func (d *directed[K, T]) EdgeByHashes(sourceHash, targetHash K, options ...func(
 	edge := Edge[T]{
 		Source: source,
 		Target: target,
-		properties: edgeProperties{
+		Properties: EdgeProperties{
 			Attributes: make(map[string]string),
 		},
 	}
 
 	for _, option := range options {
-		option(&edge.properties)
+		option(&edge.Properties)
 	}
 
 	d.addEdge(sourceHash, targetHash, edge)
@@ -380,7 +380,7 @@ func (d *directed[K, T]) ShortestPathByHashes(sourceHash, targetHash K) ([]K, er
 		}
 
 		for successor, edge := range outEdges {
-			weight := weights[vertex] + float64(edge.properties.Weight)
+			weight := weights[vertex] + float64(edge.Properties.Weight)
 
 			if weight < weights[successor] && !hasInfiniteWeight {
 				weights[successor] = weight
@@ -416,8 +416,8 @@ func (d *directed[K, T]) AdjacencyMap() map[K]map[K]Edge[K] {
 			adjacencyMap[vertexHash][adjacencyHash] = Edge[K]{
 				Source: vertexHash,
 				Target: adjacencyHash,
-				properties: edgeProperties{
-					Weight: edge.properties.Weight,
+				Properties: EdgeProperties{
+					Weight: edge.Properties.Weight,
 				},
 			}
 		}

--- a/directed_test.go
+++ b/directed_test.go
@@ -61,18 +61,10 @@ func TestDirected_Vertex(t *testing.T) {
 }
 
 func TestDirected_Edge(t *testing.T) {
-	TestDirected_WeightedEdge(t)
-}
-
-func TestDirected_WeightedEdge(t *testing.T) {
-	TestDirected_WeightedEdgeByHashes(t)
+	TestDirected_EdgeByHashes(t)
 }
 
 func TestDirected_EdgeByHashes(t *testing.T) {
-	TestDirected_WeightedEdgeByHashes(t)
-}
-
-func TestDirected_WeightedEdgeByHashes(t *testing.T) {
 	tests := map[string]struct {
 		vertices      []int
 		edgeHashes    [][3]int
@@ -87,8 +79,20 @@ func TestDirected_WeightedEdgeByHashes(t *testing.T) {
 			edgeHashes: [][3]int{{1, 2, 10}, {1, 3, 20}},
 			traits:     &Traits{},
 			expectedEdges: []Edge[int]{
-				{Source: 1, Target: 2, Weight: 10},
-				{Source: 1, Target: 3, Weight: 20},
+				{
+					Source: 1,
+					Target: 2,
+					properties: edgeProperties{
+						Weight: 10,
+					},
+				},
+				{
+					Source: 1,
+					Target: 3,
+					properties: edgeProperties{
+						Weight: 20,
+					},
+				},
 			},
 		},
 		"hashes for non-existent vertices": {
@@ -117,7 +121,7 @@ func TestDirected_WeightedEdgeByHashes(t *testing.T) {
 		var err error
 
 		for _, edge := range test.edgeHashes {
-			if err = graph.WeightedEdgeByHashes(edge[0], edge[1], edge[2]); err != nil {
+			if err = graph.EdgeByHashes(edge[0], edge[1], EdgeWeight(edge[1])); err != nil {
 				break
 			}
 		}
@@ -143,8 +147,8 @@ func TestDirected_WeightedEdgeByHashes(t *testing.T) {
 				t.Errorf("%s: edge targets don't match: expected target %v, got %v", name, expectedEdge.Target, edge.Target)
 			}
 
-			if edge.Weight != expectedEdge.Weight {
-				t.Errorf("%s: edge weights don't match: expected weight %v, got %v", name, expectedEdge.Weight, edge.Weight)
+			if edge.properties.Weight != expectedEdge.properties.Weight {
+				t.Errorf("%s: edge weights don't match: expected weight %v, got %v", name, expectedEdge.properties.Weight, edge.properties.Weight)
 			}
 		}
 	}
@@ -595,16 +599,16 @@ func TestDirected_ShortestPathByHashes(t *testing.T) {
 		"graph as on img/dijkstra.svg": {
 			vertices: []string{"A", "B", "C", "D", "E", "F", "G"},
 			edges: []Edge[string]{
-				{Source: "A", Target: "C", Weight: 3},
-				{Source: "A", Target: "F", Weight: 2},
-				{Source: "C", Target: "D", Weight: 4},
-				{Source: "C", Target: "E", Weight: 1},
-				{Source: "C", Target: "F", Weight: 2},
-				{Source: "D", Target: "B", Weight: 1},
-				{Source: "E", Target: "B", Weight: 2},
-				{Source: "E", Target: "F", Weight: 3},
-				{Source: "F", Target: "G", Weight: 5},
-				{Source: "G", Target: "B", Weight: 2},
+				{Source: "A", Target: "C", properties: edgeProperties{Weight: 3}},
+				{Source: "A", Target: "F", properties: edgeProperties{Weight: 2}},
+				{Source: "C", Target: "D", properties: edgeProperties{Weight: 4}},
+				{Source: "C", Target: "E", properties: edgeProperties{Weight: 1}},
+				{Source: "C", Target: "F", properties: edgeProperties{Weight: 2}},
+				{Source: "D", Target: "B", properties: edgeProperties{Weight: 1}},
+				{Source: "E", Target: "B", properties: edgeProperties{Weight: 2}},
+				{Source: "E", Target: "F", properties: edgeProperties{Weight: 3}},
+				{Source: "F", Target: "G", properties: edgeProperties{Weight: 5}},
+				{Source: "G", Target: "B", properties: edgeProperties{Weight: 2}},
 			},
 			sourceHash:           "A",
 			targetHash:           "B",
@@ -613,10 +617,10 @@ func TestDirected_ShortestPathByHashes(t *testing.T) {
 		"diamond-shaped graph": {
 			vertices: []string{"A", "B", "C", "D"},
 			edges: []Edge[string]{
-				{Source: "A", Target: "B", Weight: 2},
-				{Source: "A", Target: "C", Weight: 4},
-				{Source: "B", Target: "D", Weight: 2},
-				{Source: "C", Target: "D", Weight: 2},
+				{Source: "A", Target: "B", properties: edgeProperties{Weight: 2}},
+				{Source: "A", Target: "C", properties: edgeProperties{Weight: 4}},
+				{Source: "B", Target: "D", properties: edgeProperties{Weight: 2}},
+				{Source: "C", Target: "D", properties: edgeProperties{Weight: 2}},
 			},
 			sourceHash:           "A",
 			targetHash:           "D",
@@ -625,10 +629,10 @@ func TestDirected_ShortestPathByHashes(t *testing.T) {
 		"source equal to target": {
 			vertices: []string{"A", "B", "C", "D"},
 			edges: []Edge[string]{
-				{Source: "A", Target: "B", Weight: 2},
-				{Source: "A", Target: "C", Weight: 4},
-				{Source: "B", Target: "D", Weight: 2},
-				{Source: "C", Target: "D", Weight: 2},
+				{Source: "A", Target: "B", properties: edgeProperties{Weight: 2}},
+				{Source: "A", Target: "C", properties: edgeProperties{Weight: 4}},
+				{Source: "B", Target: "D", properties: edgeProperties{Weight: 2}},
+				{Source: "C", Target: "D", properties: edgeProperties{Weight: 2}},
 			},
 			sourceHash:           "B",
 			targetHash:           "B",
@@ -637,8 +641,8 @@ func TestDirected_ShortestPathByHashes(t *testing.T) {
 		"target not reachable": {
 			vertices: []string{"A", "B", "C", "D"},
 			edges: []Edge[string]{
-				{Source: "A", Target: "B", Weight: 2},
-				{Source: "A", Target: "C", Weight: 4},
+				{Source: "A", Target: "B", properties: edgeProperties{Weight: 2}},
+				{Source: "A", Target: "C", properties: edgeProperties{Weight: 4}},
 			},
 			sourceHash:           "A",
 			targetHash:           "D",
@@ -655,7 +659,7 @@ func TestDirected_ShortestPathByHashes(t *testing.T) {
 		}
 
 		for _, edge := range test.edges {
-			if err := graph.WeightedEdge(edge.Source, edge.Target, edge.Weight); err != nil {
+			if err := graph.Edge(edge.Source, edge.Target, EdgeWeight(edge.properties.Weight)); err != nil {
 				t.Fatalf("%s: failed to add edge: %s", name, err.Error())
 			}
 		}
@@ -736,7 +740,7 @@ func TestDirected_AdjacencyList(t *testing.T) {
 		}
 
 		for _, edge := range test.edges {
-			if err := graph.WeightedEdge(edge.Source, edge.Target, edge.Weight); err != nil {
+			if err := graph.Edge(edge.Source, edge.Target, EdgeWeight(edge.properties.Weight)); err != nil {
 				t.Fatalf("%s: failed to add edge: %s", name, err.Error())
 			}
 		}
@@ -795,9 +799,9 @@ func TestDirected_addEdge(t *testing.T) {
 	}{
 		"add 3 edges": {
 			edges: []Edge[int]{
-				{Source: 1, Target: 2, Weight: 1},
-				{Source: 2, Target: 3, Weight: 2},
-				{Source: 3, Target: 1, Weight: 3},
+				{Source: 1, Target: 2, properties: edgeProperties{Weight: 1}},
+				{Source: 2, Target: 3, properties: edgeProperties{Weight: 2}},
+				{Source: 3, Target: 1, properties: edgeProperties{Weight: 3}},
 			},
 		},
 	}

--- a/directed_test.go
+++ b/directed_test.go
@@ -67,7 +67,7 @@ func TestDirected_Edge(t *testing.T) {
 func TestDirected_EdgeByHashes(t *testing.T) {
 	tests := map[string]struct {
 		vertices      []int
-		edgeHashes    [][3]int
+		edgeHashes    []Edge[int]
 		traits        *Traits
 		expectedEdges []Edge[int]
 		// Even though some of the WeightedEdgeByHashes calls might work, at least one of them
@@ -75,35 +75,32 @@ func TestDirected_EdgeByHashes(t *testing.T) {
 		shouldFinallyFail bool
 	}{
 		"graph with 2 edges": {
-			vertices:   []int{1, 2, 3},
-			edgeHashes: [][3]int{{1, 2, 10}, {1, 3, 20}},
-			traits:     &Traits{},
+			vertices: []int{1, 2, 3},
+			edgeHashes: []Edge[int]{
+				{Source: 1, Target: 2, Properties: EdgeProperties{Weight: 10}},
+				{Source: 1, Target: 3, Properties: EdgeProperties{Weight: 20}},
+			},
+			traits: &Traits{},
 			expectedEdges: []Edge[int]{
-				{
-					Source: 1,
-					Target: 2,
-					Properties: EdgeProperties{
-						Weight: 10,
-					},
-				},
-				{
-					Source: 1,
-					Target: 3,
-					Properties: EdgeProperties{
-						Weight: 20,
-					},
-				},
+				{Source: 1, Target: 2, Properties: EdgeProperties{Weight: 10}},
+				{Source: 1, Target: 3, Properties: EdgeProperties{Weight: 20}},
 			},
 		},
 		"hashes for non-existent vertices": {
-			vertices:          []int{1, 2},
-			edgeHashes:        [][3]int{{1, 3, 20}},
+			vertices: []int{1, 2},
+			edgeHashes: []Edge[int]{
+				{Source: 1, Target: 3, Properties: EdgeProperties{Weight: 20}},
+			},
 			traits:            &Traits{},
 			shouldFinallyFail: true,
 		},
 		"edge introducing a cycle in an acyclic graph": {
-			vertices:   []int{1, 2, 3},
-			edgeHashes: [][3]int{{1, 2, 0}, {2, 3, 0}, {3, 1, 0}},
+			vertices: []int{1, 2, 3},
+			edgeHashes: []Edge[int]{
+				{Source: 1, Target: 2},
+				{Source: 2, Target: 3},
+				{Source: 3, Target: 1},
+			},
 			traits: &Traits{
 				IsAcyclic: true,
 			},
@@ -121,7 +118,7 @@ func TestDirected_EdgeByHashes(t *testing.T) {
 		var err error
 
 		for _, edge := range test.edgeHashes {
-			if err = graph.EdgeByHashes(edge[0], edge[1], EdgeWeight(edge[2])); err != nil {
+			if err = graph.EdgeByHashes(edge.Source, edge.Target, EdgeWeight(edge.Properties.Weight)); err != nil {
 				break
 			}
 		}

--- a/directed_test.go
+++ b/directed_test.go
@@ -121,7 +121,7 @@ func TestDirected_EdgeByHashes(t *testing.T) {
 		var err error
 
 		for _, edge := range test.edgeHashes {
-			if err = graph.EdgeByHashes(edge[0], edge[1], EdgeWeight(edge[1])); err != nil {
+			if err = graph.EdgeByHashes(edge[0], edge[1], EdgeWeight(edge[2])); err != nil {
 				break
 			}
 		}

--- a/directed_test.go
+++ b/directed_test.go
@@ -82,14 +82,14 @@ func TestDirected_EdgeByHashes(t *testing.T) {
 				{
 					Source: 1,
 					Target: 2,
-					properties: edgeProperties{
+					Properties: EdgeProperties{
 						Weight: 10,
 					},
 				},
 				{
 					Source: 1,
 					Target: 3,
-					properties: edgeProperties{
+					Properties: EdgeProperties{
 						Weight: 20,
 					},
 				},
@@ -147,8 +147,8 @@ func TestDirected_EdgeByHashes(t *testing.T) {
 				t.Errorf("%s: edge targets don't match: expected target %v, got %v", name, expectedEdge.Target, edge.Target)
 			}
 
-			if edge.properties.Weight != expectedEdge.properties.Weight {
-				t.Errorf("%s: edge weights don't match: expected weight %v, got %v", name, expectedEdge.properties.Weight, edge.properties.Weight)
+			if edge.Properties.Weight != expectedEdge.Properties.Weight {
+				t.Errorf("%s: edge weights don't match: expected weight %v, got %v", name, expectedEdge.Properties.Weight, edge.Properties.Weight)
 			}
 		}
 	}
@@ -599,16 +599,16 @@ func TestDirected_ShortestPathByHashes(t *testing.T) {
 		"graph as on img/dijkstra.svg": {
 			vertices: []string{"A", "B", "C", "D", "E", "F", "G"},
 			edges: []Edge[string]{
-				{Source: "A", Target: "C", properties: edgeProperties{Weight: 3}},
-				{Source: "A", Target: "F", properties: edgeProperties{Weight: 2}},
-				{Source: "C", Target: "D", properties: edgeProperties{Weight: 4}},
-				{Source: "C", Target: "E", properties: edgeProperties{Weight: 1}},
-				{Source: "C", Target: "F", properties: edgeProperties{Weight: 2}},
-				{Source: "D", Target: "B", properties: edgeProperties{Weight: 1}},
-				{Source: "E", Target: "B", properties: edgeProperties{Weight: 2}},
-				{Source: "E", Target: "F", properties: edgeProperties{Weight: 3}},
-				{Source: "F", Target: "G", properties: edgeProperties{Weight: 5}},
-				{Source: "G", Target: "B", properties: edgeProperties{Weight: 2}},
+				{Source: "A", Target: "C", Properties: EdgeProperties{Weight: 3}},
+				{Source: "A", Target: "F", Properties: EdgeProperties{Weight: 2}},
+				{Source: "C", Target: "D", Properties: EdgeProperties{Weight: 4}},
+				{Source: "C", Target: "E", Properties: EdgeProperties{Weight: 1}},
+				{Source: "C", Target: "F", Properties: EdgeProperties{Weight: 2}},
+				{Source: "D", Target: "B", Properties: EdgeProperties{Weight: 1}},
+				{Source: "E", Target: "B", Properties: EdgeProperties{Weight: 2}},
+				{Source: "E", Target: "F", Properties: EdgeProperties{Weight: 3}},
+				{Source: "F", Target: "G", Properties: EdgeProperties{Weight: 5}},
+				{Source: "G", Target: "B", Properties: EdgeProperties{Weight: 2}},
 			},
 			sourceHash:           "A",
 			targetHash:           "B",
@@ -617,10 +617,10 @@ func TestDirected_ShortestPathByHashes(t *testing.T) {
 		"diamond-shaped graph": {
 			vertices: []string{"A", "B", "C", "D"},
 			edges: []Edge[string]{
-				{Source: "A", Target: "B", properties: edgeProperties{Weight: 2}},
-				{Source: "A", Target: "C", properties: edgeProperties{Weight: 4}},
-				{Source: "B", Target: "D", properties: edgeProperties{Weight: 2}},
-				{Source: "C", Target: "D", properties: edgeProperties{Weight: 2}},
+				{Source: "A", Target: "B", Properties: EdgeProperties{Weight: 2}},
+				{Source: "A", Target: "C", Properties: EdgeProperties{Weight: 4}},
+				{Source: "B", Target: "D", Properties: EdgeProperties{Weight: 2}},
+				{Source: "C", Target: "D", Properties: EdgeProperties{Weight: 2}},
 			},
 			sourceHash:           "A",
 			targetHash:           "D",
@@ -629,10 +629,10 @@ func TestDirected_ShortestPathByHashes(t *testing.T) {
 		"source equal to target": {
 			vertices: []string{"A", "B", "C", "D"},
 			edges: []Edge[string]{
-				{Source: "A", Target: "B", properties: edgeProperties{Weight: 2}},
-				{Source: "A", Target: "C", properties: edgeProperties{Weight: 4}},
-				{Source: "B", Target: "D", properties: edgeProperties{Weight: 2}},
-				{Source: "C", Target: "D", properties: edgeProperties{Weight: 2}},
+				{Source: "A", Target: "B", Properties: EdgeProperties{Weight: 2}},
+				{Source: "A", Target: "C", Properties: EdgeProperties{Weight: 4}},
+				{Source: "B", Target: "D", Properties: EdgeProperties{Weight: 2}},
+				{Source: "C", Target: "D", Properties: EdgeProperties{Weight: 2}},
 			},
 			sourceHash:           "B",
 			targetHash:           "B",
@@ -641,8 +641,8 @@ func TestDirected_ShortestPathByHashes(t *testing.T) {
 		"target not reachable": {
 			vertices: []string{"A", "B", "C", "D"},
 			edges: []Edge[string]{
-				{Source: "A", Target: "B", properties: edgeProperties{Weight: 2}},
-				{Source: "A", Target: "C", properties: edgeProperties{Weight: 4}},
+				{Source: "A", Target: "B", Properties: EdgeProperties{Weight: 2}},
+				{Source: "A", Target: "C", Properties: EdgeProperties{Weight: 4}},
 			},
 			sourceHash:           "A",
 			targetHash:           "D",
@@ -659,7 +659,7 @@ func TestDirected_ShortestPathByHashes(t *testing.T) {
 		}
 
 		for _, edge := range test.edges {
-			if err := graph.Edge(edge.Source, edge.Target, EdgeWeight(edge.properties.Weight)); err != nil {
+			if err := graph.Edge(edge.Source, edge.Target, EdgeWeight(edge.Properties.Weight)); err != nil {
 				t.Fatalf("%s: failed to add edge: %s", name, err.Error())
 			}
 		}
@@ -740,7 +740,7 @@ func TestDirected_AdjacencyList(t *testing.T) {
 		}
 
 		for _, edge := range test.edges {
-			if err := graph.Edge(edge.Source, edge.Target, EdgeWeight(edge.properties.Weight)); err != nil {
+			if err := graph.Edge(edge.Source, edge.Target, EdgeWeight(edge.Properties.Weight)); err != nil {
 				t.Fatalf("%s: failed to add edge: %s", name, err.Error())
 			}
 		}
@@ -799,9 +799,9 @@ func TestDirected_addEdge(t *testing.T) {
 	}{
 		"add 3 edges": {
 			edges: []Edge[int]{
-				{Source: 1, Target: 2, properties: edgeProperties{Weight: 1}},
-				{Source: 2, Target: 3, properties: edgeProperties{Weight: 2}},
-				{Source: 3, Target: 1, properties: edgeProperties{Weight: 3}},
+				{Source: 1, Target: 2, Properties: EdgeProperties{Weight: 1}},
+				{Source: 2, Target: 3, Properties: EdgeProperties{Weight: 2}},
+				{Source: 3, Target: 1, Properties: EdgeProperties{Weight: 3}},
 			},
 		},
 	}

--- a/draw/draw.go
+++ b/draw/draw.go
@@ -86,8 +86,8 @@ func generateDOT[K comparable, T any](g graph.Graph[K, T]) description {
 			statement := statement{
 				Source:     vertex,
 				Target:     adjacency,
-				Weight:     edge.Weight,
-				Attributes: edge.Attributes,
+				Weight:     edge.Properties.Weight,
+				Attributes: edge.Properties.Attributes,
 			}
 			description.Statements = append(description.Statements, statement)
 		}

--- a/graph.go
+++ b/graph.go
@@ -14,22 +14,22 @@ type Graph[K comparable, T any] interface {
 	// Edge creates an edge between the source and the target vertex. If the Directed option has
 	// been called on the graph, this is a directed edge. Returns an error if either vertex doesn't
 	// exist or the edge already exists.
-	Edge(source, target T) error
+	//
+	// Edge accepts a variety of functional options to set further edge details such as the weight
+	// or an attribute:
+	//
+	//	_ = graph.Edge("A", "B", graph.EdgeWeight(4), graph.EdgeAttribute("label", "mylabel"))
+	//
+	Edge(source, target T, options ...func(*edgeProperties)) error
 
 	// EdgeByHashes creates an edge between the source and the target vertex, but uses hash values
 	// to identify the vertices. This is convenient when you don't have the full vertex objects at
 	// hand. Returns an error if either vertex doesn't exist or the edge already exists.
 	//
 	// To obtain the hash value for a vertex, call the hashing function passed to New.
-	EdgeByHashes(sourceHash, targetHash K) error
-
-	// WeightedEdge does the same as Edge, but adds an additional weight to the created edge. In an
-	// unweighted graph, all edges have the same weight of 0.
-	WeightedEdge(source, target T, weight int) error
-
-	// WeightedEdgeByHashes does the same as EdgeByHashes, but adds an additional weight to the
-	// created edge. In an unweighted graph, all edges have the same weight of 0.
-	WeightedEdgeByHashes(sourceHash, targetHash K, weight int) error
+	//
+	// EdgeByHashes accepts the same functional options as Edge.
+	EdgeByHashes(sourceHash, targetHash K, options ...func(*edgeProperties)) error
 
 	// GetEdgeByHashes returns the edge between two vertices. The second return value indicates
 	// whether the edge exists. If the graph  is undirected, an edge with swapped source and target
@@ -183,6 +183,10 @@ type Graph[K comparable, T any] interface {
 type Edge[T any] struct {
 	Source     T
 	Target     T
+	properties edgeProperties
+}
+
+type edgeProperties struct {
 	Weight     int
 	Attributes map[string]string
 }
@@ -263,16 +267,16 @@ func IntHash(v int) int {
 
 // EdgeWeight returns a function that sets the weight of an edge to the given weight. This is a
 // functional option for the Edge and EdgeByHashes methods.
-func EdgeWeight[T any](weight int) func(*Edge[T]) {
-	return func(e *Edge[T]) {
+func EdgeWeight(weight int) func(*edgeProperties) {
+	return func(e *edgeProperties) {
 		e.Weight = weight
 	}
 }
 
 // EdgeAttribute returns a function that adds the given key-value pair to the attributes of an
 // edge. This is a functional option for the Edge and EdgeByHashes methods.
-func EdgeAttribute[T any](key, value string) func(*Edge[T]) {
-	return func(e *Edge[T]) {
+func EdgeAttribute(key, value string) func(*edgeProperties) {
+	return func(e *edgeProperties) {
 		e.Attributes[key] = value
 	}
 }

--- a/graph.go
+++ b/graph.go
@@ -20,7 +20,7 @@ type Graph[K comparable, T any] interface {
 	//
 	//	_ = graph.Edge("A", "B", graph.EdgeWeight(4), graph.EdgeAttribute("label", "mylabel"))
 	//
-	Edge(source, target T, options ...func(*edgeProperties)) error
+	Edge(source, target T, options ...func(*EdgeProperties)) error
 
 	// EdgeByHashes creates an edge between the source and the target vertex, but uses hash values
 	// to identify the vertices. This is convenient when you don't have the full vertex objects at
@@ -29,7 +29,7 @@ type Graph[K comparable, T any] interface {
 	// To obtain the hash value for a vertex, call the hashing function passed to New.
 	//
 	// EdgeByHashes accepts the same functional options as Edge.
-	EdgeByHashes(sourceHash, targetHash K, options ...func(*edgeProperties)) error
+	EdgeByHashes(sourceHash, targetHash K, options ...func(*EdgeProperties)) error
 
 	// GetEdgeByHashes returns the edge between two vertices. The second return value indicates
 	// whether the edge exists. If the graph  is undirected, an edge with swapped source and target
@@ -183,10 +183,16 @@ type Graph[K comparable, T any] interface {
 type Edge[T any] struct {
 	Source     T
 	Target     T
-	properties edgeProperties
+	Properties EdgeProperties
 }
 
-type edgeProperties struct {
+// EdgeProperties represents a set of properties that each edge posesses. They can be set when
+// adding a new edge using the functional options provided by this library:
+//
+//	g.Edge("A", "B", graph.EdgeWeight(2), graph.EdgeAttribute("color", "red"))
+//
+// The example above will create an edge with weight 2 and a "color" atttribute with value "red".
+type EdgeProperties struct {
 	Weight     int
 	Attributes map[string]string
 }
@@ -267,16 +273,16 @@ func IntHash(v int) int {
 
 // EdgeWeight returns a function that sets the weight of an edge to the given weight. This is a
 // functional option for the Edge and EdgeByHashes methods.
-func EdgeWeight(weight int) func(*edgeProperties) {
-	return func(e *edgeProperties) {
+func EdgeWeight(weight int) func(*EdgeProperties) {
+	return func(e *EdgeProperties) {
 		e.Weight = weight
 	}
 }
 
 // EdgeAttribute returns a function that adds the given key-value pair to the attributes of an
 // edge. This is a functional option for the Edge and EdgeByHashes methods.
-func EdgeAttribute(key, value string) func(*edgeProperties) {
-	return func(e *edgeProperties) {
+func EdgeAttribute(key, value string) func(*EdgeProperties) {
+	return func(e *EdgeProperties) {
 		e.Attributes[key] = value
 	}
 }

--- a/graph.go
+++ b/graph.go
@@ -234,7 +234,7 @@ type Hash[K comparable, T any] func(T) K
 //
 //	g := graph.New(graph.IntHash, graph.Directed(), graph.Acyclic())
 //
-// The obtained Graph implementation is depends on these traits.
+// Which Graph implementation will be returned depends on these traits.
 func New[K comparable, T any](hash Hash[K, T], options ...func(*Traits)) Graph[K, T] {
 	var p Traits
 
@@ -259,4 +259,20 @@ func StringHash(v string) string {
 // value. Using it as Hash will yield a Graph[int, int].
 func IntHash(v int) int {
 	return v
+}
+
+// EdgeWeight returns a function that sets the weight of an edge to the given weight. This is a
+// functional option for the Edge and EdgeByHashes methods.
+func EdgeWeight[T any](weight int) func(*Edge[T]) {
+	return func(e *Edge[T]) {
+		e.Weight = weight
+	}
+}
+
+// EdgeAttribute returns a function that adds the given key-value pair to the attributes of an
+// edge. This is a functional option for the Edge and EdgeByHashes methods.
+func EdgeAttribute[T any](key, value string) func(*Edge[T]) {
+	return func(e *Edge[T]) {
+		e.Attributes[key] = value
+	}
 }

--- a/graph_test.go
+++ b/graph_test.go
@@ -72,3 +72,64 @@ func TestIntHash(t *testing.T) {
 		}
 	}
 }
+
+func TestEdgeWeight(t *testing.T) {
+	tests := map[string]struct {
+		weight   int
+		expected *Edge[int]
+	}{
+		"weight 4": {
+			weight: 4,
+			expected: &Edge[int]{
+				Weight: 4,
+			},
+		},
+	}
+
+	for name, test := range tests {
+		e := &Edge[int]{}
+
+		EdgeWeight[int](test.weight)(e)
+
+		if e.Weight != test.expected.Weight {
+			t.Errorf("%s: weight expectation doesn't match: expected %v, got %v", name, test.expected.Weight, e.Weight)
+		}
+	}
+}
+
+func TestEdgeAttribute(t *testing.T) {
+	tests := map[string]struct {
+		key      string
+		value    string
+		expected *Edge[int]
+	}{
+		"attribute label=mylabel": {
+			key:   "label",
+			value: "mylabel",
+			expected: &Edge[int]{
+				Attributes: map[string]string{
+					"label": "mylabel",
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		e := &Edge[int]{
+			Attributes: make(map[string]string),
+		}
+
+		EdgeAttribute[int](test.key, test.value)(e)
+
+		value, ok := e.Attributes[test.key]
+		if !ok {
+			t.Errorf("%s: attribute expectaton doesn't match: key %v doesn't exist", name, test.key)
+		}
+
+		expectedValue := test.expected.Attributes[test.key]
+
+		if value != expectedValue {
+			t.Errorf("%s: value expectation doesn't match: expected %v, got %v", name, expectedValue, value)
+		}
+	}
+}

--- a/graph_test.go
+++ b/graph_test.go
@@ -76,23 +76,23 @@ func TestIntHash(t *testing.T) {
 func TestEdgeWeight(t *testing.T) {
 	tests := map[string]struct {
 		weight   int
-		expected *Edge[int]
+		expected edgeProperties
 	}{
 		"weight 4": {
 			weight: 4,
-			expected: &Edge[int]{
+			expected: edgeProperties{
 				Weight: 4,
 			},
 		},
 	}
 
 	for name, test := range tests {
-		e := &Edge[int]{}
+		properties := edgeProperties{}
 
-		EdgeWeight[int](test.weight)(e)
+		EdgeWeight(test.weight)(&properties)
 
-		if e.Weight != test.expected.Weight {
-			t.Errorf("%s: weight expectation doesn't match: expected %v, got %v", name, test.expected.Weight, e.Weight)
+		if properties.Weight != test.expected.Weight {
+			t.Errorf("%s: weight expectation doesn't match: expected %v, got %v", name, test.expected.Weight, properties.Weight)
 		}
 	}
 }
@@ -101,12 +101,12 @@ func TestEdgeAttribute(t *testing.T) {
 	tests := map[string]struct {
 		key      string
 		value    string
-		expected *Edge[int]
+		expected edgeProperties
 	}{
 		"attribute label=mylabel": {
 			key:   "label",
 			value: "mylabel",
-			expected: &Edge[int]{
+			expected: edgeProperties{
 				Attributes: map[string]string{
 					"label": "mylabel",
 				},
@@ -115,13 +115,13 @@ func TestEdgeAttribute(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		e := &Edge[int]{
+		properties := edgeProperties{
 			Attributes: make(map[string]string),
 		}
 
-		EdgeAttribute[int](test.key, test.value)(e)
+		EdgeAttribute(test.key, test.value)(&properties)
 
-		value, ok := e.Attributes[test.key]
+		value, ok := properties.Attributes[test.key]
 		if !ok {
 			t.Errorf("%s: attribute expectaton doesn't match: key %v doesn't exist", name, test.key)
 		}

--- a/graph_test.go
+++ b/graph_test.go
@@ -76,18 +76,18 @@ func TestIntHash(t *testing.T) {
 func TestEdgeWeight(t *testing.T) {
 	tests := map[string]struct {
 		weight   int
-		expected edgeProperties
+		expected EdgeProperties
 	}{
 		"weight 4": {
 			weight: 4,
-			expected: edgeProperties{
+			expected: EdgeProperties{
 				Weight: 4,
 			},
 		},
 	}
 
 	for name, test := range tests {
-		properties := edgeProperties{}
+		properties := EdgeProperties{}
 
 		EdgeWeight(test.weight)(&properties)
 
@@ -101,12 +101,12 @@ func TestEdgeAttribute(t *testing.T) {
 	tests := map[string]struct {
 		key      string
 		value    string
-		expected edgeProperties
+		expected EdgeProperties
 	}{
 		"attribute label=mylabel": {
 			key:   "label",
 			value: "mylabel",
-			expected: edgeProperties{
+			expected: EdgeProperties{
 				Attributes: map[string]string{
 					"label": "mylabel",
 				},
@@ -115,7 +115,7 @@ func TestEdgeAttribute(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		properties := edgeProperties{
+		properties := EdgeProperties{
 			Attributes: make(map[string]string),
 		}
 

--- a/undirected.go
+++ b/undirected.go
@@ -33,22 +33,14 @@ func (u *undirected[K, T]) Vertex(value T) {
 	u.vertices[hash] = value
 }
 
-func (u *undirected[K, T]) Edge(source, target T) error {
-	return u.WeightedEdge(source, target, 0)
-}
-
-func (u *undirected[K, T]) WeightedEdge(source, target T, weight int) error {
+func (u *undirected[K, T]) Edge(source, target T, options ...func(*edgeProperties)) error {
 	sourceHash := u.hash(source)
 	targetHash := u.hash(target)
 
-	return u.WeightedEdgeByHashes(sourceHash, targetHash, weight)
+	return u.EdgeByHashes(sourceHash, targetHash, options...)
 }
 
-func (u *undirected[K, T]) EdgeByHashes(sourceHash, targetHash K) error {
-	return u.WeightedEdgeByHashes(sourceHash, targetHash, 0)
-}
-
-func (u *undirected[K, T]) WeightedEdgeByHashes(sourceHash, targetHash K, weight int) error {
+func (u *undirected[K, T]) EdgeByHashes(sourceHash, targetHash K, options ...func(*edgeProperties)) error {
 	source, ok := u.vertices[sourceHash]
 	if !ok {
 		return fmt.Errorf("could not find source vertex with hash %v", sourceHash)
@@ -77,7 +69,13 @@ func (u *undirected[K, T]) WeightedEdgeByHashes(sourceHash, targetHash K, weight
 	edge := Edge[T]{
 		Source: source,
 		Target: target,
-		Weight: weight,
+		properties: edgeProperties{
+			Attributes: make(map[string]string),
+		},
+	}
+
+	for _, option := range options {
+		option(&edge.properties)
 	}
 
 	u.addEdge(sourceHash, targetHash, edge)
@@ -309,7 +307,7 @@ func (u *undirected[K, T]) ShortestPathByHashes(sourceHash, targetHash K) ([]K, 
 		}
 
 		for successor, edge := range inEdges {
-			weight := weights[vertex] + float64(edge.Weight)
+			weight := weights[vertex] + float64(edge.properties.Weight)
 
 			if weight < weights[successor] && !hasInfiniteWeight {
 				weights[successor] = weight
@@ -345,7 +343,9 @@ func (u *undirected[K, T]) AdjacencyMap() map[K]map[K]Edge[K] {
 			adjacencyMap[vertexHash][adjacencyHash] = Edge[K]{
 				Source: vertexHash,
 				Target: adjacencyHash,
-				Weight: edge.Weight,
+				properties: edgeProperties{
+					Weight: edge.properties.Weight,
+				},
 			}
 		}
 	}

--- a/undirected.go
+++ b/undirected.go
@@ -33,14 +33,14 @@ func (u *undirected[K, T]) Vertex(value T) {
 	u.vertices[hash] = value
 }
 
-func (u *undirected[K, T]) Edge(source, target T, options ...func(*edgeProperties)) error {
+func (u *undirected[K, T]) Edge(source, target T, options ...func(*EdgeProperties)) error {
 	sourceHash := u.hash(source)
 	targetHash := u.hash(target)
 
 	return u.EdgeByHashes(sourceHash, targetHash, options...)
 }
 
-func (u *undirected[K, T]) EdgeByHashes(sourceHash, targetHash K, options ...func(*edgeProperties)) error {
+func (u *undirected[K, T]) EdgeByHashes(sourceHash, targetHash K, options ...func(*EdgeProperties)) error {
 	source, ok := u.vertices[sourceHash]
 	if !ok {
 		return fmt.Errorf("could not find source vertex with hash %v", sourceHash)
@@ -69,13 +69,13 @@ func (u *undirected[K, T]) EdgeByHashes(sourceHash, targetHash K, options ...fun
 	edge := Edge[T]{
 		Source: source,
 		Target: target,
-		properties: edgeProperties{
+		Properties: EdgeProperties{
 			Attributes: make(map[string]string),
 		},
 	}
 
 	for _, option := range options {
-		option(&edge.properties)
+		option(&edge.Properties)
 	}
 
 	u.addEdge(sourceHash, targetHash, edge)
@@ -307,7 +307,7 @@ func (u *undirected[K, T]) ShortestPathByHashes(sourceHash, targetHash K) ([]K, 
 		}
 
 		for successor, edge := range inEdges {
-			weight := weights[vertex] + float64(edge.properties.Weight)
+			weight := weights[vertex] + float64(edge.Properties.Weight)
 
 			if weight < weights[successor] && !hasInfiniteWeight {
 				weights[successor] = weight
@@ -343,8 +343,8 @@ func (u *undirected[K, T]) AdjacencyMap() map[K]map[K]Edge[K] {
 			adjacencyMap[vertexHash][adjacencyHash] = Edge[K]{
 				Source: vertexHash,
 				Target: adjacencyHash,
-				properties: edgeProperties{
-					Weight: edge.properties.Weight,
+				Properties: EdgeProperties{
+					Weight: edge.Properties.Weight,
 				},
 			}
 		}

--- a/undirected_test.go
+++ b/undirected_test.go
@@ -87,8 +87,8 @@ func TestUndirected_WeightedEdgeByHashes(t *testing.T) {
 			edgeHashes: [][3]int{{1, 2, 10}, {1, 3, 20}},
 			traits:     &Traits{},
 			expectedEdges: []Edge[int]{
-				{Source: 1, Target: 2, properties: edgeProperties{Weight: 10}},
-				{Source: 1, Target: 3, properties: edgeProperties{Weight: 20}},
+				{Source: 1, Target: 2, Properties: EdgeProperties{Weight: 10}},
+				{Source: 1, Target: 3, Properties: EdgeProperties{Weight: 20}},
 			},
 		},
 		"hashes for non-existent vertices": {
@@ -143,8 +143,8 @@ func TestUndirected_WeightedEdgeByHashes(t *testing.T) {
 				t.Errorf("%s: edge targets don't match: expected target %v, got %v", name, expectedEdge.Target, edge.Target)
 			}
 
-			if edge.properties.Weight != expectedEdge.properties.Weight {
-				t.Errorf("%s: edge weights don't match: expected weight %v, got %v", name, expectedEdge.properties.Weight, edge.properties.Weight)
+			if edge.Properties.Weight != expectedEdge.Properties.Weight {
+				t.Errorf("%s: edge weights don't match: expected weight %v, got %v", name, expectedEdge.Properties.Weight, edge.Properties.Weight)
 			}
 		}
 	}
@@ -614,16 +614,16 @@ func TestUndirected_ShortestPathByHashes(t *testing.T) {
 		"graph as on img/dijkstra.svg": {
 			vertices: []string{"A", "B", "C", "D", "E", "F", "G"},
 			edges: []Edge[string]{
-				{Source: "A", Target: "C", properties: edgeProperties{Weight: 3}},
-				{Source: "A", Target: "F", properties: edgeProperties{Weight: 2}},
-				{Source: "C", Target: "D", properties: edgeProperties{Weight: 4}},
-				{Source: "C", Target: "E", properties: edgeProperties{Weight: 1}},
-				{Source: "C", Target: "F", properties: edgeProperties{Weight: 2}},
-				{Source: "D", Target: "B", properties: edgeProperties{Weight: 1}},
-				{Source: "E", Target: "B", properties: edgeProperties{Weight: 2}},
-				{Source: "E", Target: "F", properties: edgeProperties{Weight: 3}},
-				{Source: "F", Target: "G", properties: edgeProperties{Weight: 5}},
-				{Source: "G", Target: "B", properties: edgeProperties{Weight: 2}},
+				{Source: "A", Target: "C", Properties: EdgeProperties{Weight: 3}},
+				{Source: "A", Target: "F", Properties: EdgeProperties{Weight: 2}},
+				{Source: "C", Target: "D", Properties: EdgeProperties{Weight: 4}},
+				{Source: "C", Target: "E", Properties: EdgeProperties{Weight: 1}},
+				{Source: "C", Target: "F", Properties: EdgeProperties{Weight: 2}},
+				{Source: "D", Target: "B", Properties: EdgeProperties{Weight: 1}},
+				{Source: "E", Target: "B", Properties: EdgeProperties{Weight: 2}},
+				{Source: "E", Target: "F", Properties: EdgeProperties{Weight: 3}},
+				{Source: "F", Target: "G", Properties: EdgeProperties{Weight: 5}},
+				{Source: "G", Target: "B", Properties: EdgeProperties{Weight: 2}},
 			},
 			sourceHash:           "A",
 			targetHash:           "B",
@@ -632,10 +632,10 @@ func TestUndirected_ShortestPathByHashes(t *testing.T) {
 		"diamond-shaped graph": {
 			vertices: []string{"A", "B", "C", "D"},
 			edges: []Edge[string]{
-				{Source: "A", Target: "B", properties: edgeProperties{Weight: 2}},
-				{Source: "A", Target: "C", properties: edgeProperties{Weight: 4}},
-				{Source: "B", Target: "D", properties: edgeProperties{Weight: 2}},
-				{Source: "C", Target: "D", properties: edgeProperties{Weight: 2}},
+				{Source: "A", Target: "B", Properties: EdgeProperties{Weight: 2}},
+				{Source: "A", Target: "C", Properties: EdgeProperties{Weight: 4}},
+				{Source: "B", Target: "D", Properties: EdgeProperties{Weight: 2}},
+				{Source: "C", Target: "D", Properties: EdgeProperties{Weight: 2}},
 			},
 			sourceHash:           "A",
 			targetHash:           "D",
@@ -644,10 +644,10 @@ func TestUndirected_ShortestPathByHashes(t *testing.T) {
 		"source equal to target": {
 			vertices: []string{"A", "B", "C", "D"},
 			edges: []Edge[string]{
-				{Source: "A", Target: "B", properties: edgeProperties{Weight: 2}},
-				{Source: "A", Target: "C", properties: edgeProperties{Weight: 4}},
-				{Source: "B", Target: "D", properties: edgeProperties{Weight: 2}},
-				{Source: "C", Target: "D", properties: edgeProperties{Weight: 2}},
+				{Source: "A", Target: "B", Properties: EdgeProperties{Weight: 2}},
+				{Source: "A", Target: "C", Properties: EdgeProperties{Weight: 4}},
+				{Source: "B", Target: "D", Properties: EdgeProperties{Weight: 2}},
+				{Source: "C", Target: "D", Properties: EdgeProperties{Weight: 2}},
 			},
 			sourceHash:           "B",
 			targetHash:           "B",
@@ -656,8 +656,8 @@ func TestUndirected_ShortestPathByHashes(t *testing.T) {
 		"target not reachable": {
 			vertices: []string{"A", "B", "C", "D"},
 			edges: []Edge[string]{
-				{Source: "A", Target: "B", properties: edgeProperties{Weight: 2}},
-				{Source: "A", Target: "C", properties: edgeProperties{Weight: 4}},
+				{Source: "A", Target: "B", Properties: EdgeProperties{Weight: 2}},
+				{Source: "A", Target: "C", Properties: EdgeProperties{Weight: 4}},
 			},
 			sourceHash:           "A",
 			targetHash:           "D",
@@ -674,7 +674,7 @@ func TestUndirected_ShortestPathByHashes(t *testing.T) {
 		}
 
 		for _, edge := range test.edges {
-			if err := graph.Edge(edge.Source, edge.Target, EdgeWeight(edge.properties.Weight)); err != nil {
+			if err := graph.Edge(edge.Source, edge.Target, EdgeWeight(edge.Properties.Weight)); err != nil {
 				t.Fatalf("%s: failed to add edge: %s", name, err.Error())
 			}
 		}
@@ -764,7 +764,7 @@ func TestUndirected_AdjacencyList(t *testing.T) {
 		}
 
 		for _, edge := range test.edges {
-			if err := graph.Edge(edge.Source, edge.Target, EdgeWeight(edge.properties.Weight)); err != nil {
+			if err := graph.Edge(edge.Source, edge.Target, EdgeWeight(edge.Properties.Weight)); err != nil {
 				t.Fatalf("%s: failed to add edge: %s", name, err.Error())
 			}
 		}
@@ -828,9 +828,9 @@ func TestUndirected_addEdge(t *testing.T) {
 	}{
 		"add 3 edges": {
 			edges: []Edge[int]{
-				{Source: 1, Target: 2, properties: edgeProperties{Weight: 1}},
-				{Source: 2, Target: 3, properties: edgeProperties{Weight: 2}},
-				{Source: 3, Target: 1, properties: edgeProperties{Weight: 3}},
+				{Source: 1, Target: 2, Properties: EdgeProperties{Weight: 1}},
+				{Source: 2, Target: 3, Properties: EdgeProperties{Weight: 2}},
+				{Source: 3, Target: 1, Properties: EdgeProperties{Weight: 3}},
 			},
 		},
 	}

--- a/undirected_test.go
+++ b/undirected_test.go
@@ -61,18 +61,10 @@ func TestUndirected_Vertex(t *testing.T) {
 }
 
 func TestUndirected_Edge(t *testing.T) {
-	TestUndirected_WeightedEdge(t)
-}
-
-func TestUndirected_WeightedEdge(t *testing.T) {
-	TestUndirected_WeightedEdgeByHashes(t)
+	TestDirected_EdgeByHashes(t)
 }
 
 func TestUndirected_EdgeByHashes(t *testing.T) {
-	TestUndirected_WeightedEdgeByHashes(t)
-}
-
-func TestUndirected_WeightedEdgeByHashes(t *testing.T) {
 	tests := map[string]struct {
 		vertices      []int
 		edgeHashes    [][3]int

--- a/undirected_test.go
+++ b/undirected_test.go
@@ -87,8 +87,8 @@ func TestUndirected_WeightedEdgeByHashes(t *testing.T) {
 			edgeHashes: [][3]int{{1, 2, 10}, {1, 3, 20}},
 			traits:     &Traits{},
 			expectedEdges: []Edge[int]{
-				{Source: 1, Target: 2, Weight: 10},
-				{Source: 1, Target: 3, Weight: 20},
+				{Source: 1, Target: 2, properties: edgeProperties{Weight: 10}},
+				{Source: 1, Target: 3, properties: edgeProperties{Weight: 20}},
 			},
 		},
 		"hashes for non-existent vertices": {
@@ -117,7 +117,7 @@ func TestUndirected_WeightedEdgeByHashes(t *testing.T) {
 		var err error
 
 		for _, edge := range test.edgeHashes {
-			if err = graph.WeightedEdgeByHashes(edge[0], edge[1], edge[2]); err != nil {
+			if err = graph.EdgeByHashes(edge[0], edge[1], EdgeWeight(edge[2])); err != nil {
 				break
 			}
 		}
@@ -143,8 +143,8 @@ func TestUndirected_WeightedEdgeByHashes(t *testing.T) {
 				t.Errorf("%s: edge targets don't match: expected target %v, got %v", name, expectedEdge.Target, edge.Target)
 			}
 
-			if edge.Weight != expectedEdge.Weight {
-				t.Errorf("%s: edge weights don't match: expected weight %v, got %v", name, expectedEdge.Weight, edge.Weight)
+			if edge.properties.Weight != expectedEdge.properties.Weight {
+				t.Errorf("%s: edge weights don't match: expected weight %v, got %v", name, expectedEdge.properties.Weight, edge.properties.Weight)
 			}
 		}
 	}
@@ -614,16 +614,16 @@ func TestUndirected_ShortestPathByHashes(t *testing.T) {
 		"graph as on img/dijkstra.svg": {
 			vertices: []string{"A", "B", "C", "D", "E", "F", "G"},
 			edges: []Edge[string]{
-				{Source: "A", Target: "C", Weight: 3},
-				{Source: "A", Target: "F", Weight: 2},
-				{Source: "C", Target: "D", Weight: 4},
-				{Source: "C", Target: "E", Weight: 1},
-				{Source: "C", Target: "F", Weight: 2},
-				{Source: "D", Target: "B", Weight: 1},
-				{Source: "E", Target: "B", Weight: 2},
-				{Source: "E", Target: "F", Weight: 3},
-				{Source: "F", Target: "G", Weight: 5},
-				{Source: "G", Target: "B", Weight: 2},
+				{Source: "A", Target: "C", properties: edgeProperties{Weight: 3}},
+				{Source: "A", Target: "F", properties: edgeProperties{Weight: 2}},
+				{Source: "C", Target: "D", properties: edgeProperties{Weight: 4}},
+				{Source: "C", Target: "E", properties: edgeProperties{Weight: 1}},
+				{Source: "C", Target: "F", properties: edgeProperties{Weight: 2}},
+				{Source: "D", Target: "B", properties: edgeProperties{Weight: 1}},
+				{Source: "E", Target: "B", properties: edgeProperties{Weight: 2}},
+				{Source: "E", Target: "F", properties: edgeProperties{Weight: 3}},
+				{Source: "F", Target: "G", properties: edgeProperties{Weight: 5}},
+				{Source: "G", Target: "B", properties: edgeProperties{Weight: 2}},
 			},
 			sourceHash:           "A",
 			targetHash:           "B",
@@ -632,10 +632,10 @@ func TestUndirected_ShortestPathByHashes(t *testing.T) {
 		"diamond-shaped graph": {
 			vertices: []string{"A", "B", "C", "D"},
 			edges: []Edge[string]{
-				{Source: "A", Target: "B", Weight: 2},
-				{Source: "A", Target: "C", Weight: 4},
-				{Source: "B", Target: "D", Weight: 2},
-				{Source: "C", Target: "D", Weight: 2},
+				{Source: "A", Target: "B", properties: edgeProperties{Weight: 2}},
+				{Source: "A", Target: "C", properties: edgeProperties{Weight: 4}},
+				{Source: "B", Target: "D", properties: edgeProperties{Weight: 2}},
+				{Source: "C", Target: "D", properties: edgeProperties{Weight: 2}},
 			},
 			sourceHash:           "A",
 			targetHash:           "D",
@@ -644,10 +644,10 @@ func TestUndirected_ShortestPathByHashes(t *testing.T) {
 		"source equal to target": {
 			vertices: []string{"A", "B", "C", "D"},
 			edges: []Edge[string]{
-				{Source: "A", Target: "B", Weight: 2},
-				{Source: "A", Target: "C", Weight: 4},
-				{Source: "B", Target: "D", Weight: 2},
-				{Source: "C", Target: "D", Weight: 2},
+				{Source: "A", Target: "B", properties: edgeProperties{Weight: 2}},
+				{Source: "A", Target: "C", properties: edgeProperties{Weight: 4}},
+				{Source: "B", Target: "D", properties: edgeProperties{Weight: 2}},
+				{Source: "C", Target: "D", properties: edgeProperties{Weight: 2}},
 			},
 			sourceHash:           "B",
 			targetHash:           "B",
@@ -656,8 +656,8 @@ func TestUndirected_ShortestPathByHashes(t *testing.T) {
 		"target not reachable": {
 			vertices: []string{"A", "B", "C", "D"},
 			edges: []Edge[string]{
-				{Source: "A", Target: "B", Weight: 2},
-				{Source: "A", Target: "C", Weight: 4},
+				{Source: "A", Target: "B", properties: edgeProperties{Weight: 2}},
+				{Source: "A", Target: "C", properties: edgeProperties{Weight: 4}},
 			},
 			sourceHash:           "A",
 			targetHash:           "D",
@@ -674,7 +674,7 @@ func TestUndirected_ShortestPathByHashes(t *testing.T) {
 		}
 
 		for _, edge := range test.edges {
-			if err := graph.WeightedEdge(edge.Source, edge.Target, edge.Weight); err != nil {
+			if err := graph.Edge(edge.Source, edge.Target, EdgeWeight(edge.properties.Weight)); err != nil {
 				t.Fatalf("%s: failed to add edge: %s", name, err.Error())
 			}
 		}
@@ -764,7 +764,7 @@ func TestUndirected_AdjacencyList(t *testing.T) {
 		}
 
 		for _, edge := range test.edges {
-			if err := graph.WeightedEdge(edge.Source, edge.Target, edge.Weight); err != nil {
+			if err := graph.Edge(edge.Source, edge.Target, EdgeWeight(edge.properties.Weight)); err != nil {
 				t.Fatalf("%s: failed to add edge: %s", name, err.Error())
 			}
 		}
@@ -828,9 +828,9 @@ func TestUndirected_addEdge(t *testing.T) {
 	}{
 		"add 3 edges": {
 			edges: []Edge[int]{
-				{Source: 1, Target: 2, Weight: 1},
-				{Source: 2, Target: 3, Weight: 2},
-				{Source: 3, Target: 1, Weight: 3},
+				{Source: 1, Target: 2, properties: edgeProperties{Weight: 1}},
+				{Source: 2, Target: 3, properties: edgeProperties{Weight: 2}},
+				{Source: 3, Target: 1, properties: edgeProperties{Weight: 3}},
 			},
 		},
 	}


### PR DESCRIPTION
Closes #13.

## Changelog:

### Added
* Added the `EdgeWeight` and `EdgeAttribute` functional options.
* Added the `Properties` field to `Edge`.

### Changed
* Changed `Edge` to accept a variadic `options` parameter.
* Changed `EdgeByHashes` to accept a variadic `options` parameter.

### Removed
* Removed the `WeightedEdge` function. Use `Edge` with the `EdgeWeight` functional option instead.
* Removed the `WeightedEdgeByHashes` function. Use `EdgeByHashes` with the `EdgeWeight` functional option instead.