### PR TITLE
Convert lint target to golangci-lint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: 1.48
+          version: v1.48
       - name: Test
         run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
   test:
@@ -24,10 +23,9 @@ jobs:
         run: |
           go get -v -t -d ./...
       - name: Lint
-        run: |
-          go vet -stdmethods=false $(go list ./...)
-          go install mvdan.cc/gofumpt@latest
-          test -z "$(gofumpt -l -extra .)" || echo "Please run 'gofumpt -l -w -extra .'"
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: 1.48
       - name: Test
         run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,17 @@
+run:
+  timeout: 5m
+
+linters:
+  disable-all: true
+  enable:
+    - govet
+    - gofumpt
+
+linters-settings:
+  govet:
+    disable:
+      - stdmethods
+
+  gofumpt:
+    extra-rules: true
+    module-path: github.com/dominikbraun/graph

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
     - govet
     - gofumpt
     - deadcode
+    - errcheck
 
 linters-settings:
   govet:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     - errcheck
     - gosimple
     - ineffassign
+    - staticcheck
 
 linters-settings:
   govet:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - staticcheck
     - typecheck
     - unused
+    - varcheck
 
 linters-settings:
   govet:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
   enable:
     - govet
     - gofumpt
+    - deadcode
 
 linters-settings:
   govet:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ linters:
     - gosimple
     - ineffassign
     - staticcheck
+    - typecheck
 
 linters-settings:
   govet:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - gofumpt
     - deadcode
     - errcheck
+    - gosimple
 
 linters-settings:
   govet:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters:
     - deadcode
     - errcheck
     - gosimple
+    - ineffassign
 
 linters-settings:
   govet:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
 
 linters-settings:
   govet:
+    enable-all: true
     disable:
       - stdmethods
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - ineffassign
     - staticcheck
     - typecheck
+    - unused
 
 linters-settings:
   govet:

--- a/collection_test.go
+++ b/collection_test.go
@@ -90,9 +90,9 @@ func TestPriorityQueue_Pop(t *testing.T) {
 func TestPriorityQueue_DecreasePriority(t *testing.T) {
 	tests := map[string]struct {
 		items                 []priorityItem[int]
+		expectedPriorityItems []priorityItem[int]
 		decreaseItem          int
 		decreasePriority      float64
-		expectedPriorityItems []priorityItem[int]
 	}{
 		"decrease 30 to priority 5": {
 			items: []priorityItem[int]{
@@ -188,10 +188,10 @@ func TestPriorityQueue_Len(t *testing.T) {
 func TestPriorityQueue_insertItemAt(t *testing.T) {
 	tests := map[string]struct {
 		items                 []priorityItem[int]
+		expectedPriorityItems []priorityItem[int]
 		insertItem            int
 		insertPriority        float64
 		insertIndex           int
-		expectedPriorityItems []priorityItem[int]
 	}{
 		"insert in the middle of the queue": {
 			items: []priorityItem[int]{

--- a/directed.go
+++ b/directed.go
@@ -221,9 +221,7 @@ func (d *directed[K, T]) CreatesCycleByHashes(sourceHash, targetHash K) (bool, e
 			}
 			visited[currentHash] = true
 
-			for _, predecessor := range d.predecessors(currentHash) {
-				stack = append(stack, predecessor)
-			}
+			stack = append(stack, d.predecessors(currentHash)...)
 		}
 	}
 
@@ -277,7 +275,7 @@ func (d *directed[K, T]) StronglyConnectedComponents() ([][]K, error) {
 	}
 
 	for hash := range d.vertices {
-		if ok, _ := state.visited[hash]; !ok {
+		if ok := state.visited[hash]; !ok {
 			d.findSCC(hash, state)
 		}
 	}
@@ -295,7 +293,7 @@ func (d *directed[K, T]) findSCC(vertexHash K, state *sccState[K]) {
 	state.time++
 
 	for adjancency := range d.outEdges[vertexHash] {
-		if ok, _ := state.visited[adjancency]; !ok {
+		if ok := state.visited[adjancency]; !ok {
 			d.findSCC(adjancency, state)
 
 			smallestLowlink := math.Min(
@@ -307,7 +305,7 @@ func (d *directed[K, T]) findSCC(vertexHash K, state *sccState[K]) {
 			// If the adjacent vertex already is on the stack, the edge joining the current and the
 			// adjacent vertex is a back edge. Therefore, update the vertex' lowlink value to the
 			// index of the adjacent vertex if it is smaller than the lowlink value.
-			if ok, _ := state.onStack[adjancency]; ok {
+			if ok := state.onStack[adjancency]; ok {
 				smallestLowlink := math.Min(
 					float64(state.lowlink[vertexHash]),
 					float64(state.index[adjancency]),

--- a/directed.go
+++ b/directed.go
@@ -267,7 +267,6 @@ type sccState[K comparable] struct {
 // the hashes of the vertices shaping these components. The current implementation of this function
 // uses Tarjan's algorithm and runs recursively.
 func (d *directed[K, T]) StronglyConnectedComponents() ([][]K, error) {
-
 	state := &sccState[K]{
 		components: make([][]K, 0),
 		stack:      make([]K, 0),

--- a/directed.go
+++ b/directed.go
@@ -252,12 +252,12 @@ func (d *directed[K, T]) DegreeByHash(vertexHash K) (int, error) {
 }
 
 type sccState[K comparable] struct {
-	components [][]K
-	stack      []K
 	onStack    map[K]bool
 	visited    map[K]bool
 	lowlink    map[K]int
 	index      map[K]int
+	components [][]K
+	stack      []K
 	time       int
 }
 

--- a/directed_test.go
+++ b/directed_test.go
@@ -249,8 +249,8 @@ func TestDirected_DFSByHash(t *testing.T) {
 	tests := map[string]struct {
 		vertices       []int
 		edges          []Edge[int]
-		startHash      int
 		expectedVisits []int
+		startHash      int
 		stopAtVertex   int
 	}{
 		"traverse entire graph with 3 vertices": {
@@ -345,8 +345,8 @@ func TestDirected_BFSByHash(t *testing.T) {
 	tests := map[string]struct {
 		vertices       []int
 		edges          []Edge[int]
-		startHash      int
 		expectedVisits []int
+		startHash      int
 		stopAtVertex   int
 	}{
 		"traverse entire graph with 3 vertices": {
@@ -731,9 +731,9 @@ func TestDirected_ShortestPathByHashes(t *testing.T) {
 
 func TestDirected_AdjacencyList(t *testing.T) {
 	tests := map[string]struct {
+		expected map[int]map[int]Edge[int]
 		vertices []int
 		edges    []Edge[int]
-		expected map[int]map[int]Edge[int]
 	}{
 		"Y-shaped graph": {
 			vertices: []int{1, 2, 3, 4},
@@ -878,8 +878,8 @@ func TestDirected_predecessors(t *testing.T) {
 	tests := map[string]struct {
 		vertices             []int
 		edges                []Edge[int]
-		vertex               int
 		expectedPredecessors []int
+		vertex               int
 	}{
 		"graph with 3 vertices": {
 			vertices: []int{1, 2, 3},

--- a/directed_test.go
+++ b/directed_test.go
@@ -229,7 +229,9 @@ func TestDirected_GetEdgeByHashes(t *testing.T) {
 		sourceHash := graph.hash(test.vertices[0])
 		targetHash := graph.hash(test.vertices[1])
 
-		graph.EdgeByHashes(sourceHash, targetHash)
+		if err := graph.EdgeByHashes(sourceHash, targetHash); err != nil {
+			t.Fatal("unexpected error:", err)
+		}
 
 		_, ok := graph.GetEdgeByHashes(test.getEdgeHashes[0], test.getEdgeHashes[1])
 

--- a/directed_test.go
+++ b/directed_test.go
@@ -933,7 +933,7 @@ func TestDirected_predecessors(t *testing.T) {
 	}
 }
 
-func slicesAreEqual[T comparable](a []T, b []T) bool {
+func slicesAreEqual[T comparable](a, b []T) bool {
 	if len(a) != len(b) {
 		return false
 	}

--- a/draw/draw.go
+++ b/draw/draw.go
@@ -26,8 +26,8 @@ type description struct {
 type statement struct {
 	Source     interface{}
 	Target     interface{}
-	Weight     int
 	Attributes map[string]string
+	Weight     int
 }
 
 // DOT renders the given graph structure in DOT language into an io.Writer, for example a file. The
@@ -56,44 +56,44 @@ type statement struct {
 //
 //	go run main.go | dot -Tsvg > output.svg
 func DOT[K comparable, T any](g graph.Graph[K, T], w io.Writer) error {
-	description := generateDOT(g)
+	desc := generateDOT(g)
 
-	return renderDOT(w, description)
+	return renderDOT(w, desc)
 }
 
 func generateDOT[K comparable, T any](g graph.Graph[K, T]) description {
-	description := description{
+	desc := description{
 		GraphType:    "graph",
 		EdgeOperator: "--",
 		Statements:   make([]statement, 0),
 	}
 
 	if g.Traits().IsDirected {
-		description.GraphType = "digraph"
-		description.EdgeOperator = "->"
+		desc.GraphType = "digraph"
+		desc.EdgeOperator = "->"
 	}
 
 	for vertex, adjacencies := range g.AdjacencyMap() {
 		if len(adjacencies) == 0 {
-			statement := statement{
+			stmt := statement{
 				Source: vertex,
 			}
-			description.Statements = append(description.Statements, statement)
+			desc.Statements = append(desc.Statements, stmt)
 			continue
 		}
 
 		for adjacency, edge := range adjacencies {
-			statement := statement{
+			stmt := statement{
 				Source:     vertex,
 				Target:     adjacency,
 				Weight:     edge.Properties.Weight,
 				Attributes: edge.Properties.Attributes,
 			}
-			description.Statements = append(description.Statements, statement)
+			desc.Statements = append(desc.Statements, stmt)
 		}
 	}
 
-	return description
+	return desc
 }
 
 func renderDOT(w io.Writer, d description) error {

--- a/draw/draw_test.go
+++ b/draw/draw_test.go
@@ -162,7 +162,9 @@ func TestRenderDOT(t *testing.T) {
 
 	for name, test := range tests {
 		buf := new(bytes.Buffer)
-		renderDOT(buf, test.description)
+		if err := renderDOT(buf, test.description); err != nil {
+			t.Fatal("unexpected error", err)
+		}
 
 		output := normalizeOutput(buf.String())
 		expected := normalizeOutput(test.expected)

--- a/draw/draw_test.go
+++ b/draw/draw_test.go
@@ -89,26 +89,26 @@ func TestGenerateDOT(t *testing.T) {
 			}
 		}
 
-		description := generateDOT(test.graph)
+		desc := generateDOT(test.graph)
 
-		if description.GraphType != test.expected.GraphType {
-			t.Errorf("%s: graph type expectancy doesn't match: expected %v, got %v", name, test.expected.GraphType, description.GraphType)
+		if desc.GraphType != test.expected.GraphType {
+			t.Errorf("%s: graph type expectancy doesn't match: expected %v, got %v", name, test.expected.GraphType, desc.GraphType)
 		}
 
-		if description.EdgeOperator != test.expected.EdgeOperator {
-			t.Errorf("%s: edge operator expectancy doesn't match: expected %v, got %v", name, test.expected.EdgeOperator, description.EdgeOperator)
+		if desc.EdgeOperator != test.expected.EdgeOperator {
+			t.Errorf("%s: edge operator expectancy doesn't match: expected %v, got %v", name, test.expected.EdgeOperator, desc.EdgeOperator)
 		}
 
-		if !slicesAreEqual(description.Statements, test.expected.Statements, statementsAreEqual) {
-			t.Errorf("%s: statements expectancy doesn't match: expected %v, got %v", name, test.expected.Statements, description.Statements)
+		if !slicesAreEqual(desc.Statements, test.expected.Statements, statementsAreEqual) {
+			t.Errorf("%s: statements expectancy doesn't match: expected %v, got %v", name, test.expected.Statements, desc.Statements)
 		}
 	}
 }
 
 func TestRenderDOT(t *testing.T) {
 	tests := map[string]struct {
-		description description
 		expected    string
+		description description
 	}{
 		"3-vertex directed graph": {
 			description: description{

--- a/draw/draw_test.go
+++ b/draw/draw_test.go
@@ -173,7 +173,7 @@ func TestRenderDOT(t *testing.T) {
 	}
 }
 
-func slicesAreEqual[T any](a []T, b []T, equals func(a, b T) bool) bool {
+func slicesAreEqual[T any](a, b []T, equals func(a, b T) bool) bool {
 	if len(a) != len(b) {
 		return false
 	}

--- a/graph.go
+++ b/graph.go
@@ -3,7 +3,6 @@ package graph
 // Graph represents a generic graph data structure consisting of vertices and edges. Its vertices
 // are of type T, and each vertex is identified by a hash of type K.
 type Graph[K comparable, T any] interface {
-
 	// Traits returns the graph's traits. Those traits must be set when creating a graph using New.
 	Traits() *Traits
 

--- a/graph.go
+++ b/graph.go
@@ -192,8 +192,8 @@ type Edge[T any] struct {
 //
 // The example above will create an edge with weight 2 and a "color" atttribute with value "red".
 type EdgeProperties struct {
-	Weight     int
 	Attributes map[string]string
+	Weight     int
 }
 
 // Hash is a hashing function that takes a vertex of type T and returns a hash value of type K.

--- a/graph_test.go
+++ b/graph_test.go
@@ -10,8 +10,8 @@ func TestNew(t *testing.T) {
 	undirectedType := reflect.TypeOf(&undirected[int, int]{})
 
 	tests := map[string]struct {
-		options      []func(*Traits)
 		expectedType reflect.Type
+		options      []func(*Traits)
 	}{
 		"no options": {
 			options:      []func(*Traits){},
@@ -75,8 +75,8 @@ func TestIntHash(t *testing.T) {
 
 func TestEdgeWeight(t *testing.T) {
 	tests := map[string]struct {
-		weight   int
 		expected EdgeProperties
+		weight   int
 	}{
 		"weight 4": {
 			weight: 4,

--- a/undirected.go
+++ b/undirected.go
@@ -226,10 +226,7 @@ func (u *undirected[K, T]) CreatesCycleByHashes(sourceHash, targetHash K) (bool,
 				return true, nil
 			}
 			visited[currentHash] = true
-
-			for _, adjacency := range u.adjacencies(currentHash) {
-				stack = append(stack, adjacency)
-			}
+			stack = append(stack, u.adjacencies(currentHash)...)
 		}
 	}
 

--- a/undirected.go
+++ b/undirected.go
@@ -95,7 +95,8 @@ func (u *undirected[K, T]) GetEdgeByHashes(sourceHash, targetHash K) (Edge[T], b
 	// Therefore, if source[target] cannot be found, this function also looks for target[source].
 	sourceEdges, ok := u.outEdges[sourceHash]
 	if ok {
-		if edge, ok := sourceEdges[targetHash]; ok {
+		var edge Edge[T]
+		if edge, ok = sourceEdges[targetHash]; ok {
 			return edge, true
 		}
 	}

--- a/undirected_test.go
+++ b/undirected_test.go
@@ -191,15 +191,12 @@ func TestUndirected_DFS(t *testing.T) {
 
 func TestUndirected_DFSByHash(t *testing.T) {
 	tests := map[string]struct {
-		vertices  []int
-		edges     []Edge[int]
-		startHash int
-		// It is not possible to expect a strict list of vertices to be visited. If stopAtVertex is
-		// a neighbor of another vertex, that other vertex might be visited before stopAtVertex.
+		vertices              []int
+		edges                 []Edge[int]
 		expectedMinimumVisits []int
-		// In case stopAtVertex has downstream neighbors, those neighbors musn't be visited.
-		forbiddenVisits []int
-		stopAtVertex    int
+		forbiddenVisits       []int
+		startHash             int
+		stopAtVertex          int
 	}{
 		"traverse entire graph with 3 vertices": {
 			vertices: []int{1, 2, 3},
@@ -341,8 +338,8 @@ func TestUndirected_BFSByHash(t *testing.T) {
 	tests := map[string]struct {
 		vertices       []int
 		edges          []Edge[int]
-		startHash      int
 		expectedVisits []int
+		startHash      int
 		stopAtVertex   int
 	}{
 		"traverse entire graph with 3 vertices": {
@@ -693,9 +690,9 @@ func TestUndirected_ShortestPathByHashes(t *testing.T) {
 
 func TestUndirected_AdjacencyList(t *testing.T) {
 	tests := map[string]struct {
+		expected map[int]map[int]Edge[int]
 		vertices []int
 		edges    []Edge[int]
-		expected map[int]map[int]Edge[int]
 	}{
 		"Y-shaped graph": {
 			vertices: []int{1, 2, 3, 4},
@@ -851,8 +848,8 @@ func TestUndirected_adjacencies(t *testing.T) {
 	tests := map[string]struct {
 		vertices             []int
 		edges                []Edge[int]
-		vertex               int
 		expectedAdjancencies []int
+		vertex               int
 	}{
 		"graph with 3 vertices": {
 			vertices: []int{1, 2, 3},

--- a/undirected_test.go
+++ b/undirected_test.go
@@ -173,7 +173,9 @@ func TestUndirected_GetEdgeByHashes(t *testing.T) {
 		sourceHash := graph.hash(test.vertices[0])
 		targetHash := graph.hash(test.vertices[1])
 
-		graph.EdgeByHashes(sourceHash, targetHash)
+		if err := graph.EdgeByHashes(sourceHash, targetHash); err != nil {
+			t.Fatal("unexpected error:", err)
+		}
 
 		_, ok := graph.GetEdgeByHashes(test.getEdgeHashes[0], test.getEdgeHashes[1])
 


### PR DESCRIPTION
Enable only the existing lints to start and run with --fix on the project, committing the results.

Closes #26 