### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ g.AddVertex(3)
 _ = g.AddEdge(1, 2)
 _ = g.AddEdge(1, 3)
 
-if err := g.Edge(2, 3); err != nil {
+if err := g.AddEdge(2, 3); err != nil {
     panic(err)
 }
 ```


### PR DESCRIPTION
For acyclic graphs, locating an edge shouldn't return a cyclic error, instead adding an edge returns the error. Updating the README to show that change.