### PR TITLE
Proposal: Decouple vertice/edge store from graphs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,14 +6,12 @@ linters:
   enable:
     - govet
     - gofumpt
-    - deadcode
     - errcheck
     - gosimple
     - ineffassign
     - staticcheck
     - typecheck
     - unused
-    - varcheck
 
 linters-settings:
   govet:

--- a/dag.go
+++ b/dag.go
@@ -52,7 +52,12 @@ func TopologicalSort[K comparable, T any](g Graph[K, T]) ([]K, error) {
 		}
 	}
 
-	if len(order) != g.Order() {
+	gOrder, err := g.Order()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get graph order: %w", err)
+	}
+
+	if len(order) != gOrder {
 		return nil, errors.New("topological sort cannot be computed on graph with cycles")
 	}
 
@@ -85,10 +90,14 @@ func TransitiveReduction[K comparable, T any](g Graph[K, T]) (Graph[K, T], error
 		//
 		// These edges are redundant because their targets obviously are reachable through the DFS,
 		// hence they can be removed from the top-level vertex.
+		tOrder, err := transitiveReduction.Order()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get graph order: %w", err)
+		}
 		for successor := range successors {
-			stack := make([]K, 0, transitiveReduction.Order())
-			visited := make(map[K]struct{}, transitiveReduction.Order())
-			onStack := make(map[K]bool, transitiveReduction.Order())
+			stack := make([]K, 0, tOrder)
+			visited := make(map[K]struct{}, tOrder)
+			onStack := make(map[K]bool, tOrder)
 
 			stack = append(stack, successor)
 

--- a/directed.go
+++ b/directed.go
@@ -149,9 +149,6 @@ func (d *directed[K, T]) AdjacencyMap() (map[K]map[K]Edge[K], error) {
 	}
 
 	for _, edge := range edges {
-		if _, ok := m[edge.Source]; !ok {
-			m[edge.Source] = make(map[K]Edge[K])
-		}
 		m[edge.Source][edge.Target] = edge
 	}
 

--- a/directed.go
+++ b/directed.go
@@ -158,7 +158,7 @@ func (d *directed[K, T]) Clone() (Graph[K, T], error) {
 }
 
 func (d *directed[K, T]) Order() (int, error) {
-	return d.store.CountVertices()
+	return d.store.VertexCount()
 }
 
 func (d *directed[K, T]) Size() (int, error) {

--- a/directed.go
+++ b/directed.go
@@ -54,12 +54,12 @@ func (d *directed[K, T]) VertexWithProperties(hash K) (T, VertexProperties, erro
 func (d *directed[K, T]) AddEdge(sourceHash, targetHash K, options ...func(*EdgeProperties)) error {
 	_, _, err := d.store.Vertex(sourceHash)
 	if err != nil {
-		return fmt.Errorf("source vertex %v: %w", sourceHash, ErrVertexNotFound)
+		return fmt.Errorf("source vertex %v: %w", sourceHash, err)
 	}
 
 	_, _, err = d.store.Vertex(targetHash)
 	if err != nil {
-		return fmt.Errorf("target vertex %v: %w", targetHash, ErrVertexNotFound)
+		return fmt.Errorf("target vertex %v: %w", targetHash, err)
 	}
 
 	if _, err := d.Edge(sourceHash, targetHash); !errors.Is(err, ErrEdgeNotFound) {

--- a/directed.go
+++ b/directed.go
@@ -114,6 +114,7 @@ func (d *directed[K, T]) Edge(sourceHash, targetHash K) (Edge[T], error) {
 		Properties: EdgeProperties{
 			Weight:     edge.Properties.Weight,
 			Attributes: edge.Properties.Attributes,
+			Data:       edge.Properties.Data,
 		},
 	}, nil
 }

--- a/directed_test.go
+++ b/directed_test.go
@@ -847,7 +847,7 @@ func TestDirected_predecessors(t *testing.T) {
 			}
 		}
 
-		predecessors, _ := predecessors(graph.store, graph.hash(test.vertex))
+		predecessors, _ := predecessors(graph, graph.hash(test.vertex))
 
 		if !slicesAreEqual(predecessors, test.expectedPredecessors) {
 			t.Errorf("%s: predecessors don't match: expected %v, got %v", name, test.expectedPredecessors, predecessors)
@@ -875,10 +875,10 @@ func slicesAreEqual[T comparable](a, b []T) bool {
 	return true
 }
 
-func predecessors[K comparable, T any](store Store[K, T], vertexHash K) ([]K, error) {
+func predecessors[K comparable, T any](g *directed[K, T], vertexHash K) ([]K, error) {
 	var predecessorHashes []K
 
-	predicessorsMap, err := store.PredecessorMap()
+	predicessorsMap, err := g.PredecessorMap()
 	if err != nil {
 		return nil, err
 	}

--- a/directed_test.go
+++ b/directed_test.go
@@ -355,9 +355,12 @@ func TestDirected_Edge(t *testing.T) {
 		sourceHash := graph.hash(test.vertices[0])
 		targetHash := graph.hash(test.vertices[1])
 
-		_ = graph.AddEdge(sourceHash, targetHash)
+		err := graph.AddEdge(sourceHash, targetHash)
+		if err != nil {
+			t.Fatalf("%s: error adding edge: %v", name, err)
+		}
 
-		_, err := graph.Edge(test.getEdgeHashes[0], test.getEdgeHashes[1])
+		_, err = graph.Edge(test.getEdgeHashes[0], test.getEdgeHashes[1])
 
 		if test.exists != (err == nil) {
 			t.Fatalf("%s: result expectancy doesn't match: expected %v, got %v", name, test.exists, err)
@@ -774,7 +777,10 @@ func TestDirected_addEdge(t *testing.T) {
 		for _, edge := range test.edges {
 			sourceHash := graph.hash(edge.Source)
 			TargetHash := graph.hash(edge.Target)
-			graph.addEdge(sourceHash, TargetHash, edge)
+			err := graph.addEdge(sourceHash, TargetHash, edge)
+			if err != nil {
+				t.Fatalf("%s: failed to add edge: %s", name, err.Error())
+			}
 		}
 
 		outEdges := graph.store.(*memoryStore[int, int]).outEdges

--- a/directed_test.go
+++ b/directed_test.go
@@ -276,7 +276,13 @@ func TestDirected_AddEdge(t *testing.T) {
 			// If there are edge attributes, iterate over them and call EdgeAttribute for each
 			// entry. An edge should only have one attribute so that AddEdge is invoked once.
 			for key, value := range edge.Properties.Attributes {
-				err = graph.AddEdge(edge.Source, edge.Target, EdgeWeight(edge.Properties.Weight), EdgeData(edge.Properties.Data), EdgeAttribute(key, value))
+				err = graph.AddEdge(
+					edge.Source,
+					edge.Target,
+					EdgeWeight(edge.Properties.Weight),
+					EdgeData(edge.Properties.Data),
+					EdgeAttribute(key, value),
+				)
 			}
 			if err != nil {
 				break

--- a/directed_test.go
+++ b/directed_test.go
@@ -884,12 +884,12 @@ func slicesAreEqual[T comparable](a, b []T) bool {
 func predecessors[K comparable, T any](g *directed[K, T], vertexHash K) ([]K, error) {
 	var predecessorHashes []K
 
-	predicessorsMap, err := g.PredecessorMap()
+	predecessorMap, err := g.PredecessorMap()
 	if err != nil {
 		return nil, err
 	}
 
-	for _, edge := range predicessorsMap[vertexHash] {
+	for _, edge := range predecessorMap[vertexHash] {
 		predecessorHashes = append(predecessorHashes, edge.Source)
 	}
 

--- a/directed_test.go
+++ b/directed_test.go
@@ -872,12 +872,12 @@ func slicesAreEqual[T comparable](a, b []T) bool {
 func predecessors[K comparable, T any](store Store[K, T], vertexHash K) ([]K, error) {
 	var predecessorHashes []K
 
-	inEdges, err := store.GetEdgesByTarget(vertexHash)
+	predicessorsMap, err := store.PredecessorMap()
 	if err != nil {
 		return nil, err
 	}
 
-	for _, edge := range inEdges {
+	for _, edge := range predicessorsMap[vertexHash] {
 		predecessorHashes = append(predecessorHashes, edge.Source)
 	}
 

--- a/graph.go
+++ b/graph.go
@@ -89,10 +89,10 @@ type Graph[K comparable, T any] interface {
 	Clone() (Graph[K, T], error)
 
 	// Order computes and returns the number of vertices in the graph.
-	Order() int
+	Order() (int, error)
 
 	// Size computes and returns the number of edges in the graph.
-	Size() int
+	Size() (int, error)
 }
 
 // Edge represents a graph edge with a source and target vertex as well as a weight, which has the
@@ -171,11 +171,13 @@ func New[K comparable, T any](hash Hash[K, T], options ...func(*Traits)) Graph[K
 		option(&p)
 	}
 
+	s := newMemoryStore[K, T]()
+
 	if p.IsDirected {
-		return newDirected(hash, &p)
+		return newDirected(hash, &p, s)
 	}
 
-	return newUndirected(hash, &p)
+	return newUndirected(hash, &p, s)
 }
 
 // StringHash is a hashing function that accepts a string and uses that exact string as a hash

--- a/graph.go
+++ b/graph.go
@@ -165,19 +165,23 @@ type Hash[K comparable, T any] func(T) K
 //
 // Which Graph implementation will be returned depends on these traits.
 func New[K comparable, T any](hash Hash[K, T], options ...func(*Traits)) Graph[K, T] {
+	return NewWithStore(hash, newMemoryStore[K, T](), options...)
+}
+
+// NewWithStore creates a new graph same as New, but uses the provided store instead of the default
+// memory store.
+func NewWithStore[K comparable, T any](hash Hash[K, T], store Store[K, T], options ...func(*Traits)) Graph[K, T] {
 	var p Traits
 
 	for _, option := range options {
 		option(&p)
 	}
 
-	s := newMemoryStore[K, T]()
-
 	if p.IsDirected {
-		return newDirected(hash, &p, s)
+		return newDirected(hash, &p, store)
 	}
 
-	return newUndirected(hash, &p, s)
+	return newUndirected(hash, &p, store)
 }
 
 // StringHash is a hashing function that accepts a string and uses that exact string as a hash

--- a/store.go
+++ b/store.go
@@ -9,6 +9,4 @@ type Store[K comparable, T any] interface {
 	RemoveEdge(sourceHash, targetHash K) error
 	Edge(sourceHash, targetHash K) (Edge[K], error)
 	ListEdges() ([]Edge[K], error)
-	GetEdgesBySource(sourceHash K) ([]Edge[K], error)
-	GetEdgesByTarget(targetHash K) ([]Edge[K], error)
 }

--- a/store.go
+++ b/store.go
@@ -4,7 +4,7 @@ type Store[K comparable, T any] interface {
 	AddVertex(hash K, value T, properties VertexProperties) error
 	Vertex(hash K) (T, VertexProperties, error)
 	ListVertices() ([]K, error)
-	CountVertices() (int, error)
+	VertexCount() (int, error)
 	AddEdge(sourceHash, targetHash K, edge Edge[K]) error
 	RemoveEdge(sourceHash, targetHash K) error
 	Edge(sourceHash, targetHash K) (Edge[K], error)

--- a/store.go
+++ b/store.go
@@ -1,0 +1,15 @@
+package graph
+
+type Store[K comparable, T any] interface {
+	AddVertex(hash K, value T, properties VertexProperties) error
+	Vertex(hash K) (T, VertexProperties, error)
+	ListVertices() ([]K, error)
+	CountVertices() (int, error)
+	AddEdge(sourceHash, targetHash K, edge Edge[K]) error
+	RemoveEdge(sourceHash, targetHash K) error
+	Edge(sourceHash, targetHash K) (Edge[K], error)
+	GetEdgesBySource(sourceHash K) ([]Edge[K], error)
+	GetEdgesByTarget(targetHash K) ([]Edge[K], error)
+	AdjacencyMap() (map[K]map[K]Edge[K], error)
+	PredecessorMap() (map[K]map[K]Edge[K], error)
+}

--- a/store.go
+++ b/store.go
@@ -8,8 +8,7 @@ type Store[K comparable, T any] interface {
 	AddEdge(sourceHash, targetHash K, edge Edge[K]) error
 	RemoveEdge(sourceHash, targetHash K) error
 	Edge(sourceHash, targetHash K) (Edge[K], error)
+	ListEdges() ([]Edge[K], error)
 	GetEdgesBySource(sourceHash K) ([]Edge[K], error)
 	GetEdgesByTarget(targetHash K) ([]Edge[K], error)
-	AdjacencyMap() (map[K]map[K]Edge[K], error)
-	PredecessorMap() (map[K]map[K]Edge[K], error)
 }

--- a/store_memory.go
+++ b/store_memory.go
@@ -1,0 +1,195 @@
+package graph
+
+import (
+	"sync"
+)
+
+type memoryStore[K comparable, T any] struct {
+	lock             sync.RWMutex
+	vertices         map[K]T
+	vertexProperties map[K]VertexProperties
+	outEdges         map[K]map[K]Edge[K] // source -> target
+	inEdges          map[K]map[K]Edge[K] // target -> source
+}
+
+func newMemoryStore[K comparable, T any]() Store[K, T] {
+	return &memoryStore[K, T]{
+		vertices:         make(map[K]T),
+		vertexProperties: make(map[K]VertexProperties),
+		outEdges:         make(map[K]map[K]Edge[K]),
+		inEdges:          make(map[K]map[K]Edge[K]),
+	}
+}
+
+func (s *memoryStore[K, T]) AddVertex(k K, t T, p VertexProperties) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if _, ok := s.vertices[k]; ok {
+		return ErrVertexAlreadyExists
+	}
+
+	s.vertices[k] = t
+	s.vertexProperties[k] = p
+
+	return nil
+}
+
+func (s *memoryStore[K, T]) ListVertices() ([]K, error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	var hashes []K
+	for k := range s.vertices {
+		hashes = append(hashes, k)
+	}
+
+	return hashes, nil
+}
+
+func (s *memoryStore[K, T]) CountVertices() (int, error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	return len(s.vertices), nil
+}
+
+func (s *memoryStore[K, T]) Vertex(k K) (T, VertexProperties, error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	var v T
+	var ok bool
+	v, ok = s.vertices[k]
+	if !ok {
+		return v, VertexProperties{}, ErrVertexNotFound
+	}
+
+	p := s.vertexProperties[k]
+	return v, p, nil
+}
+
+func (s *memoryStore[K, T]) AddEdge(sourceHash, targetHash K, edge Edge[K]) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if _, ok := s.outEdges[sourceHash]; !ok {
+		s.outEdges[sourceHash] = make(map[K]Edge[K])
+	}
+
+	s.outEdges[sourceHash][targetHash] = edge
+
+	if _, ok := s.inEdges[targetHash]; !ok {
+		s.inEdges[targetHash] = make(map[K]Edge[K])
+	}
+
+	s.inEdges[targetHash][sourceHash] = edge
+
+	return nil
+}
+
+func (s *memoryStore[K, T]) RemoveEdge(sourceHash, targetHash K) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	delete(s.inEdges[sourceHash], targetHash)
+	delete(s.outEdges[sourceHash], targetHash)
+	return nil
+}
+
+func (s *memoryStore[K, T]) Edge(sourceHash, targetHash K) (Edge[K], error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	sourceEdges, ok := s.outEdges[sourceHash]
+	if !ok {
+		return Edge[K]{}, ErrEdgeNotFound
+	}
+
+	edge, ok := sourceEdges[targetHash]
+	if !ok {
+		return Edge[K]{}, ErrEdgeNotFound
+	}
+
+	return edge, nil
+}
+
+func (s *memoryStore[K, T]) GetEdgesBySource(sourceHash K) ([]Edge[K], error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	sourceEdges, ok := s.outEdges[sourceHash]
+	if !ok {
+		return nil, ErrEdgeNotFound
+	}
+
+	sourceEdgesArray := make([]Edge[K], 0, len(sourceEdges))
+	for _, edge := range sourceEdges {
+		sourceEdgesArray = append(sourceEdgesArray, edge)
+	}
+
+	return sourceEdgesArray, nil
+}
+
+func (s *memoryStore[K, T]) GetEdgesByTarget(targetHash K) ([]Edge[K], error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	targetEdges, ok := s.inEdges[targetHash]
+	if !ok {
+		return nil, ErrEdgeNotFound
+	}
+
+	targetEdgesArray := make([]Edge[K], 0, len(targetEdges))
+	for _, edge := range targetEdges {
+		targetEdgesArray = append(targetEdgesArray, edge)
+	}
+
+	return targetEdgesArray, nil
+}
+
+func (s *memoryStore[K, T]) AdjacencyMap() (map[K]map[K]Edge[K], error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	m := make(map[K]map[K]Edge[K])
+
+	for hash := range s.vertices {
+		m[hash] = make(map[K]Edge[K])
+	}
+
+	for sourceHash, targetEdges := range s.outEdges {
+		m[sourceHash] = make(map[K]Edge[K])
+		for targetHash, edge := range targetEdges {
+			m[sourceHash][targetHash] = edge
+		}
+	}
+
+	return m, nil
+}
+
+func (s *memoryStore[K, T]) PredecessorMap() (map[K]map[K]Edge[K], error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	predecessors := make(map[K]map[K]Edge[K])
+
+	for vertexHash := range s.vertices {
+		predecessors[vertexHash] = make(map[K]Edge[K])
+	}
+
+	for vertexHash, inEdges := range s.inEdges {
+		for predecessorHash, edge := range inEdges {
+			predecessors[vertexHash][predecessorHash] = Edge[K]{
+				Source: predecessorHash,
+				Target: vertexHash,
+				Properties: EdgeProperties{
+					Attributes: edge.Properties.Attributes,
+					Weight:     edge.Properties.Weight,
+				},
+			}
+		}
+	}
+
+	return predecessors, nil
+}

--- a/store_memory.go
+++ b/store_memory.go
@@ -193,3 +193,13 @@ func (s *memoryStore[K, T]) PredecessorMap() (map[K]map[K]Edge[K], error) {
 
 	return predecessors, nil
 }
+
+func (s *memoryStore[K, T]) ListEdges() ([]Edge[K], error) {
+	res := make([]Edge[K], 0)
+	for _, edges := range s.outEdges {
+		for _, edge := range edges {
+			res = append(res, edge)
+		}
+	}
+	return res, nil
+}

--- a/store_memory.go
+++ b/store_memory.go
@@ -148,52 +148,6 @@ func (s *memoryStore[K, T]) GetEdgesByTarget(targetHash K) ([]Edge[K], error) {
 	return targetEdgesArray, nil
 }
 
-func (s *memoryStore[K, T]) AdjacencyMap() (map[K]map[K]Edge[K], error) {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
-
-	m := make(map[K]map[K]Edge[K])
-
-	for hash := range s.vertices {
-		m[hash] = make(map[K]Edge[K])
-	}
-
-	for sourceHash, targetEdges := range s.outEdges {
-		m[sourceHash] = make(map[K]Edge[K])
-		for targetHash, edge := range targetEdges {
-			m[sourceHash][targetHash] = edge
-		}
-	}
-
-	return m, nil
-}
-
-func (s *memoryStore[K, T]) PredecessorMap() (map[K]map[K]Edge[K], error) {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
-
-	predecessors := make(map[K]map[K]Edge[K])
-
-	for vertexHash := range s.vertices {
-		predecessors[vertexHash] = make(map[K]Edge[K])
-	}
-
-	for vertexHash, inEdges := range s.inEdges {
-		for predecessorHash, edge := range inEdges {
-			predecessors[vertexHash][predecessorHash] = Edge[K]{
-				Source: predecessorHash,
-				Target: vertexHash,
-				Properties: EdgeProperties{
-					Attributes: edge.Properties.Attributes,
-					Weight:     edge.Properties.Weight,
-				},
-			}
-		}
-	}
-
-	return predecessors, nil
-}
-
 func (s *memoryStore[K, T]) ListEdges() ([]Edge[K], error) {
 	res := make([]Edge[K], 0)
 	for _, edges := range s.outEdges {

--- a/store_memory.go
+++ b/store_memory.go
@@ -114,40 +114,6 @@ func (s *memoryStore[K, T]) Edge(sourceHash, targetHash K) (Edge[K], error) {
 	return edge, nil
 }
 
-func (s *memoryStore[K, T]) GetEdgesBySource(sourceHash K) ([]Edge[K], error) {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
-
-	sourceEdges, ok := s.outEdges[sourceHash]
-	if !ok {
-		return nil, ErrEdgeNotFound
-	}
-
-	sourceEdgesArray := make([]Edge[K], 0, len(sourceEdges))
-	for _, edge := range sourceEdges {
-		sourceEdgesArray = append(sourceEdgesArray, edge)
-	}
-
-	return sourceEdgesArray, nil
-}
-
-func (s *memoryStore[K, T]) GetEdgesByTarget(targetHash K) ([]Edge[K], error) {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
-
-	targetEdges, ok := s.inEdges[targetHash]
-	if !ok {
-		return nil, ErrEdgeNotFound
-	}
-
-	targetEdgesArray := make([]Edge[K], 0, len(targetEdges))
-	for _, edge := range targetEdges {
-		targetEdgesArray = append(targetEdgesArray, edge)
-	}
-
-	return targetEdgesArray, nil
-}
-
 func (s *memoryStore[K, T]) ListEdges() ([]Edge[K], error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()

--- a/store_memory.go
+++ b/store_memory.go
@@ -47,7 +47,7 @@ func (s *memoryStore[K, T]) ListVertices() ([]K, error) {
 	return hashes, nil
 }
 
-func (s *memoryStore[K, T]) CountVertices() (int, error) {
+func (s *memoryStore[K, T]) VertexCount() (int, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 

--- a/store_memory.go
+++ b/store_memory.go
@@ -149,6 +149,9 @@ func (s *memoryStore[K, T]) GetEdgesByTarget(targetHash K) ([]Edge[K], error) {
 }
 
 func (s *memoryStore[K, T]) ListEdges() ([]Edge[K], error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
 	res := make([]Edge[K], 0)
 	for _, edges := range s.outEdges {
 		for _, edge := range edges {

--- a/undirected.go
+++ b/undirected.go
@@ -55,14 +55,15 @@ func (u *undirected[K, T]) VertexWithProperties(hash K) (T, VertexProperties, er
 func (u *undirected[K, T]) AddEdge(sourceHash, targetHash K, options ...func(*EdgeProperties)) error {
 	_, _, err := u.store.Vertex(sourceHash)
 	if err != nil {
-		return fmt.Errorf("could not find source vertex with hash %v", sourceHash)
+		return fmt.Errorf("could not find source vertex with hash %v: %w", sourceHash, err)
 	}
 
 	_, _, err = u.store.Vertex(targetHash)
 	if err != nil {
-		return fmt.Errorf("could not find target vertex with hash %v", targetHash)
+		return fmt.Errorf("could not find target vertex with hash %v: %w", targetHash, err)
 	}
 
+	// nolint: govet // false positive err shawdowing
 	if _, err := u.Edge(sourceHash, targetHash); !errors.Is(err, ErrEdgeNotFound) {
 		return ErrEdgeAlreadyExists
 	}

--- a/undirected.go
+++ b/undirected.go
@@ -148,7 +148,30 @@ func (u *undirected[K, T]) RemoveEdge(source, target K) error {
 }
 
 func (u *undirected[K, T]) AdjacencyMap() (map[K]map[K]Edge[K], error) {
-	return u.store.AdjacencyMap()
+	vertices, err := u.store.ListVertices()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list vertices: %w", err)
+	}
+
+	edges, err := u.store.ListEdges()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list edges: %w", err)
+	}
+
+	m := make(map[K]map[K]Edge[K])
+
+	for _, vertex := range vertices {
+		m[vertex] = make(map[K]Edge[K])
+	}
+
+	for _, edge := range edges {
+		if _, ok := m[edge.Source]; !ok {
+			m[edge.Source] = make(map[K]Edge[K])
+		}
+		m[edge.Source][edge.Target] = edge
+	}
+
+	return m, nil
 }
 
 func (u *undirected[K, T]) PredecessorMap() (map[K]map[K]Edge[K], error) {
@@ -176,7 +199,7 @@ func (u *undirected[K, T]) Order() (int, error) {
 
 func (u *undirected[K, T]) Size() (int, error) {
 	size := 0
-	outEdges, err := u.store.AdjacencyMap()
+	outEdges, err := u.AdjacencyMap()
 	if err != nil {
 		return 0, fmt.Errorf("failed to get adjacency map: %w", err)
 	}

--- a/undirected.go
+++ b/undirected.go
@@ -102,16 +102,13 @@ func (u *undirected[K, T]) Edge(sourceHash, targetHash K) (Edge[T], error) {
 	// In an undirected graph, since multigraphs aren't supported, the edge AB is the same as BA.
 	// Therefore, if source[target] cannot be found, this function also looks for target[source].
 
-	// TODO(@geoah): this can be better probably
 	edge, err := u.store.Edge(sourceHash, targetHash)
-	if err != nil && !errors.Is(err, ErrEdgeNotFound) {
-		return Edge[T]{}, err
-	}
-	if err != nil {
+	if errors.Is(err, ErrEdgeNotFound) {
 		edge, err = u.store.Edge(targetHash, sourceHash)
-		if err != nil {
-			return Edge[T]{}, err
-		}
+	}
+
+	if err != nil {
+		return Edge[T]{}, err
 	}
 
 	sourceVertex, _, err := u.store.Vertex(sourceHash)

--- a/undirected.go
+++ b/undirected.go
@@ -53,13 +53,11 @@ func (u *undirected[K, T]) VertexWithProperties(hash K) (T, VertexProperties, er
 }
 
 func (u *undirected[K, T]) AddEdge(sourceHash, targetHash K, options ...func(*EdgeProperties)) error {
-	_, _, err := u.store.Vertex(sourceHash)
-	if err != nil {
+	if _, _, err := u.store.Vertex(sourceHash); err != nil {
 		return fmt.Errorf("could not find source vertex with hash %v: %w", sourceHash, err)
 	}
 
-	_, _, err = u.store.Vertex(targetHash)
-	if err != nil {
+	if _, _, err := u.store.Vertex(targetHash); err != nil {
 		return fmt.Errorf("could not find target vertex with hash %v: %w", targetHash, err)
 	}
 
@@ -91,8 +89,7 @@ func (u *undirected[K, T]) AddEdge(sourceHash, targetHash K, options ...func(*Ed
 		option(&edge.Properties)
 	}
 
-	err = u.addEdge(sourceHash, targetHash, edge)
-	if err != nil {
+	if err := u.addEdge(sourceHash, targetHash, edge); err != nil {
 		return fmt.Errorf("failed to add edge: %w", err)
 	}
 

--- a/undirected.go
+++ b/undirected.go
@@ -238,6 +238,7 @@ func (u *undirected[K, T]) addEdge(sourceHash, targetHash K, edge Edge[K]) error
 		Properties: EdgeProperties{
 			Weight:     edge.Properties.Weight,
 			Attributes: edge.Properties.Attributes,
+			Data:       edge.Properties.Data,
 		},
 	}
 

--- a/undirected.go
+++ b/undirected.go
@@ -163,9 +163,6 @@ func (u *undirected[K, T]) AdjacencyMap() (map[K]map[K]Edge[K], error) {
 	}
 
 	for _, edge := range edges {
-		if _, ok := m[edge.Source]; !ok {
-			m[edge.Source] = make(map[K]Edge[K])
-		}
 		m[edge.Source][edge.Target] = edge
 	}
 

--- a/undirected.go
+++ b/undirected.go
@@ -174,7 +174,7 @@ func (u *undirected[K, T]) Clone() (Graph[K, T], error) {
 }
 
 func (u *undirected[K, T]) Order() (int, error) {
-	return u.store.CountVertices()
+	return u.store.VertexCount()
 }
 
 func (u *undirected[K, T]) Size() (int, error) {

--- a/undirected.go
+++ b/undirected.go
@@ -90,7 +90,10 @@ func (u *undirected[K, T]) AddEdge(sourceHash, targetHash K, options ...func(*Ed
 		option(&edge.Properties)
 	}
 
-	u.addEdge(sourceHash, targetHash, edge)
+	err = u.addEdge(sourceHash, targetHash, edge)
+	if err != nil {
+		return fmt.Errorf("failed to add edge: %w", err)
+	}
 
 	return nil
 }

--- a/undirected_test.go
+++ b/undirected_test.go
@@ -358,9 +358,12 @@ func TestUndirected_Edge(t *testing.T) {
 		sourceHash := graph.hash(test.vertices[0])
 		targetHash := graph.hash(test.vertices[1])
 
-		_ = graph.AddEdge(sourceHash, targetHash)
+		err := graph.AddEdge(sourceHash, targetHash)
+		if err != nil {
+			t.Fatalf("%s: error adding edge: %v", name, err)
+		}
 
-		_, err := graph.Edge(test.getEdgeHashes[0], test.getEdgeHashes[1])
+		_, err = graph.Edge(test.getEdgeHashes[0], test.getEdgeHashes[1])
 
 		if test.exists != (err == nil) {
 			t.Fatalf("%s: result expectancy doesn't match: expected %v, got %v", name, test.exists, err)
@@ -800,7 +803,10 @@ func TestUndirected_addEdge(t *testing.T) {
 		for _, edge := range test.edges {
 			sourceHash := graph.hash(edge.Source)
 			TargetHash := graph.hash(edge.Target)
-			graph.addEdge(sourceHash, TargetHash, edge)
+			err := graph.addEdge(sourceHash, TargetHash, edge)
+			if err != nil {
+				t.Fatalf("%s: failed to add edge: %s", name, err.Error())
+			}
 		}
 
 		outEdges := graph.store.(*memoryStore[int, int]).outEdges

--- a/undirected_test.go
+++ b/undirected_test.go
@@ -21,7 +21,7 @@ func TestUndirected_Traits(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		g := newUndirected(IntHash, test.traits)
+		g := newUndirected(IntHash, test.traits, newMemoryStore[int, int]())
 		traits := g.Traits()
 
 		if !traitsAreEqual(traits, test.expected) {
@@ -60,7 +60,7 @@ func TestUndirected_AddVertex(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		graph := newUndirected(IntHash, &Traits{})
+		graph := newUndirected(IntHash, &Traits{}, newMemoryStore[int, int]())
 
 		var err error
 
@@ -80,30 +80,33 @@ func TestUndirected_AddVertex(t *testing.T) {
 			t.Errorf("%s: error expectancy doesn't match: expected %v, got %v", name, test.finallyExpectedError, err)
 		}
 
+		graphStore := graph.store.(*memoryStore[int, int])
+
 		for _, vertex := range test.vertices {
-			if len(graph.vertices) != len(test.expectedVertices) {
-				t.Errorf("%s: vertex count doesn't match: expected %v, got %v", name, len(test.expectedVertices), len(graph.vertices))
+			if len(graphStore.vertices) != len(test.expectedVertices) {
+				t.Errorf("%s: vertex count doesn't match: expected %v, got %v", name, len(test.expectedVertices), len(graphStore.vertices))
 			}
 
 			hash := graph.hash(vertex)
-			if _, ok := graph.vertices[hash]; !ok {
-				t.Errorf("%s: vertex %v not found in graph: %v", name, vertex, graph.vertices)
+			vertices := graph.store.(*memoryStore[int, int]).vertices
+			if _, ok := vertices[hash]; !ok {
+				t.Errorf("%s: vertex %v not found in graph: %v", name, vertex, vertices)
 			}
 
 			if test.properties == nil {
 				continue
 			}
 
-			if graph.vertexProperties[hash].Weight != test.expectedProperties.Weight {
-				t.Errorf("%s: edge weights don't match: expected weight %v, got %v", name, test.expectedProperties.Weight, graph.vertexProperties[hash].Weight)
+			if graphStore.vertexProperties[hash].Weight != test.expectedProperties.Weight {
+				t.Errorf("%s: edge weights don't match: expected weight %v, got %v", name, test.expectedProperties.Weight, graphStore.vertexProperties[hash].Weight)
 			}
 
-			if len(graph.vertexProperties[hash].Attributes) != len(test.expectedProperties.Attributes) {
-				t.Fatalf("%s: attributes lengths don't match: expcted %v, got %v", name, len(test.expectedProperties.Attributes), len(graph.vertexProperties[hash].Attributes))
+			if len(graphStore.vertexProperties[hash].Attributes) != len(test.expectedProperties.Attributes) {
+				t.Fatalf("%s: attributes lengths don't match: expcted %v, got %v", name, len(test.expectedProperties.Attributes), len(graphStore.vertexProperties[hash].Attributes))
 			}
 
 			for expectedKey, expectedValue := range test.expectedProperties.Attributes {
-				value, ok := graph.vertexProperties[hash].Attributes[expectedKey]
+				value, ok := graphStore.vertexProperties[hash].Attributes[expectedKey]
 				if !ok {
 					t.Errorf("%s: attribute keys don't match: expected key %v not found", name, expectedKey)
 				}
@@ -133,7 +136,7 @@ func TestUndirected_Vertex(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		graph := newUndirected(IntHash, &Traits{})
+		graph := newUndirected(IntHash, &Traits{}, newMemoryStore[int, int]())
 
 		for _, vertex := range test.vertices {
 			_ = graph.AddVertex(vertex)
@@ -259,7 +262,7 @@ func TestUndirected_AddEdge(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		graph := newUndirected(IntHash, test.traits)
+		graph := newUndirected(IntHash, test.traits, newMemoryStore[int, int]())
 
 		for _, vertex := range test.vertices {
 			_ = graph.AddVertex(vertex)
@@ -289,7 +292,7 @@ func TestUndirected_AddEdge(t *testing.T) {
 			sourceHash := graph.hash(expectedEdge.Source)
 			targetHash := graph.hash(expectedEdge.Target)
 
-			edge, ok := graph.outEdges[sourceHash][targetHash]
+			edge, ok := graph.store.(*memoryStore[int, int]).outEdges[sourceHash][targetHash]
 			if !ok {
 				t.Fatalf("%s: edge with source %v and target %v not found", name, expectedEdge.Source, expectedEdge.Target)
 			}
@@ -346,7 +349,7 @@ func TestUndirected_Edge(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		graph := newUndirected(IntHash, &Traits{})
+		graph := newUndirected(IntHash, &Traits{}, newMemoryStore[int, int]())
 
 		for _, vertex := range test.vertices {
 			_ = graph.AddVertex(vertex)
@@ -490,7 +493,7 @@ func TestUndirected_Adjacencies(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		graph := newUndirected(IntHash, &Traits{})
+		graph := newUndirected(IntHash, &Traits{}, newMemoryStore[int, int]())
 
 		for _, vertex := range test.vertices {
 			_ = graph.AddVertex(vertex)
@@ -583,7 +586,7 @@ func TestUndirected_PredecessorMap(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		graph := newUndirected(IntHash, &Traits{})
+		graph := newUndirected(IntHash, &Traits{}, newMemoryStore[int, int]())
 
 		for _, vertex := range test.vertices {
 			_ = graph.AddVertex(vertex)
@@ -669,31 +672,8 @@ func TestUndirected_Clone(t *testing.T) {
 			t.Errorf("%s: traits expectancy doesn't match: expected %v, got %v", name, expected.traits, actual.traits)
 		}
 
-		if len(actual.vertices) != len(expected.vertices) {
-			t.Fatalf("%s: vertices length expectancy doesn't match: expected %v, got %v", name, len(expected.vertices), len(actual.vertices))
-		}
-
-		for expectedHash, expectedVertex := range expected.vertices {
-			actualVertex, ok := actual.vertices[expectedHash]
-			if !ok {
-				t.Errorf("%s: vertex expectancy doesn't match: expected vertex %v doesn't exist", name, expectedVertex)
-			}
-			if actualVertex != expectedVertex {
-				t.Errorf("%s: vertex expectancy doesn't match: expected %v, got %v", name, expectedVertex, actualVertex)
-			}
-			if actual.vertexProperties[expectedHash].Weight != expected.vertexProperties[expectedHash].Weight {
-				t.Errorf("%s: vertex properties expectancy doesn't match: expected %v, got %v", name, expected.vertexProperties[expectedHash], actual.vertexProperties[expectedHash])
-			}
-			if actual.vertexProperties[expectedHash].Attributes["color"] != expected.vertexProperties[expectedHash].Attributes["color"] {
-				t.Errorf("%s: vertex properties expectancy doesn't match: expected %v, got %v", name, expected.vertexProperties[expectedHash], actual.vertexProperties[expectedHash])
-			}
-		}
-
-		if len(actual.inEdges) != len(expected.inEdges) {
-			t.Errorf("%s: number of inEdges doesn't match: expected %v, got %v", name, len(expected.inEdges), len(actual.inEdges))
-		}
-		if len(actual.outEdges) != len(expected.outEdges) {
-			t.Errorf("%s: number of outEdges doesn't match: expected %v, got %v", name, len(expected.outEdges), len(actual.outEdges))
+		if actual.store != expected.store {
+			t.Fatalf("%s: stores don't match", name)
 		}
 	}
 }
@@ -743,7 +723,7 @@ func TestUndirected_OrderAndSize(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		graph := newUndirected(IntHash, &Traits{})
+		graph := newUndirected(IntHash, &Traits{}, newMemoryStore[int, int]())
 
 		for _, vertex := range test.vertices {
 			_ = graph.AddVertex(vertex)
@@ -755,8 +735,8 @@ func TestUndirected_OrderAndSize(t *testing.T) {
 			}
 		}
 
-		order := graph.Order()
-		size := graph.Size()
+		order, _ := graph.Order()
+		size, _ := graph.Size()
 
 		if order != test.expectedOrder {
 			t.Errorf("%s: order expectancy doesn't match: expected %d, got %d", name, test.expectedOrder, order)
@@ -792,7 +772,7 @@ func TestUndirected_edgesAreEqual(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		graph := newUndirected(IntHash, &Traits{})
+		graph := newUndirected(IntHash, &Traits{}, newMemoryStore[int, int]())
 		actual := graph.edgesAreEqual(test.a, test.b)
 
 		if actual != test.edgesAreEqual {
@@ -815,7 +795,7 @@ func TestUndirected_addEdge(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		graph := newUndirected(IntHash, &Traits{})
+		graph := newUndirected(IntHash, &Traits{}, newMemoryStore[int, int]())
 
 		for _, edge := range test.edges {
 			sourceHash := graph.hash(edge.Source)
@@ -823,11 +803,13 @@ func TestUndirected_addEdge(t *testing.T) {
 			graph.addEdge(sourceHash, TargetHash, edge)
 		}
 
-		if len(graph.outEdges) != len(test.edges) {
-			t.Errorf("%s: number of outgoing edges doesn't match: expected %v, got %v", name, len(test.edges), len(graph.outEdges))
+		outEdges := graph.store.(*memoryStore[int, int]).outEdges
+		if len(outEdges) != len(test.edges) {
+			t.Errorf("%s: number of outgoing edges doesn't match: expected %v, got %v", name, len(test.edges), len(outEdges))
 		}
-		if len(graph.inEdges) != len(test.edges) {
-			t.Errorf("%s: number of ingoing edges doesn't match: expected %v, got %v", name, len(test.edges), len(graph.inEdges))
+		inEdges := graph.store.(*memoryStore[int, int]).inEdges
+		if len(inEdges) != len(test.edges) {
+			t.Errorf("%s: number of ingoing edges doesn't match: expected %v, got %v", name, len(test.edges), len(inEdges))
 		}
 	}
 }
@@ -905,7 +887,7 @@ func TestUndirected_adjacencies(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		graph := newUndirected(IntHash, &Traits{})
+		graph := newUndirected(IntHash, &Traits{}, newMemoryStore[int, int]())
 
 		for _, vertex := range test.vertices {
 			_ = graph.AddVertex(vertex)
@@ -917,10 +899,27 @@ func TestUndirected_adjacencies(t *testing.T) {
 			}
 		}
 
-		adjacencies := graph.adjacencies(graph.hash(test.vertex))
+		adjacencies := adjacencies(graph.store, graph.hash(test.vertex))
 
 		if !slicesAreEqual(adjacencies, test.expectedAdjancencies) {
 			t.Errorf("%s: adjacencies don't match: expected %v, got %v", name, test.expectedAdjancencies, adjacencies)
 		}
 	}
+}
+
+func adjacencies[K comparable, T any](store Store[K, T], vertexHash K) []K {
+	var adjacencyHashes []K
+
+	// An undirected graph creates an undirected edge as two directed edges in the opposite
+	// direction, so both the in-edges and the out-edges work here.
+	inEdges, ok := store.(*memoryStore[K, T]).inEdges[vertexHash]
+	if !ok {
+		return adjacencyHashes
+	}
+
+	for hash := range inEdges {
+		adjacencyHashes = append(adjacencyHashes, hash)
+	}
+
+	return adjacencyHashes
 }


### PR DESCRIPTION
Hey @dominikbraun, sorry for the delay, managed to get some time to give this another shot.

The pull requests lifts-and-shifts the storage part of the verticies and edges into its own store interface so that we can then start implementing additional non in-memory stores.

```golang
type Store[K comparable, T any] interface {
	AddVertex(hash K, value T) error
	Vertex(hash K) (T, error)
	ListVertices() ([]K, error) // not currently used
	CountVertices() (int, error)
	AddEdge(sourceHash, targetHash K, edge Edge[K]) error
	RemoveEdge(sourceHash, targetHash K) error
	Edge(sourceHash, targetHash K) (Edge[K], error)
	GetEdgesBySource(sourceHash K) ([]Edge[K], error)
	GetEdgesByTarget(targetHash K) ([]Edge[K], error) // not currently used
	AdjacencyMap() (map[K]map[K]Edge[K], error)
	PredecessorMap() (map[K]map[K]Edge[K], error)
}
```

I see that you're consistantly making changes to the api of the graph, and I'm kind of worried that this change might be a bit restrictive for iterating quickly.

Please do take a look and let me know what you think and if there is a different direction you think might make more sense.

Regards, George