### PR TITLE
Add a key check for the bestPredecessor map

### DIFF
--- a/paths.go
+++ b/paths.go
@@ -128,6 +128,11 @@ func ShortestPath[K comparable, T any](g Graph[K, T], source, target K) ([]K, er
 	hashCursor := target
 
 	for hashCursor != source {
+		// if hashCursor is not a pressent key in bestPredecessors, hashCursor is set to the zero value
+		// without check this leads to endless prepending of zeros to the path
+		if _, ok := bestPredecessors[hashCursor]; !ok {
+			return nil, fmt.Errorf("vertex %v is not reachable from vertex %v", target, source)
+		}
 		hashCursor = bestPredecessors[hashCursor]
 		path = append([]K{hashCursor}, path...)
 	}

--- a/paths_test.go
+++ b/paths_test.go
@@ -216,6 +216,17 @@ func TestDirectedShortestPath(t *testing.T) {
 			expectedShortestPath: []string{},
 			shouldFail:           true,
 		},
+		"target not reachable connected directed graph ": {
+			vertices: []string{"A", "B", "C"},
+			edges: []Edge[string]{
+				{Source: "A", Target: "B", Properties: EdgeProperties{Weight: 0}},
+				{Source: "A", Target: "C", Properties: EdgeProperties{Weight: 0}},
+			},
+			sourceHash:           "B",
+			targetHash:           "C",
+			expectedShortestPath: []string{},
+			shouldFail:           true,
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
Hi @dominikbraun, 

this fixes the non-termination of the ShortestPath function as seen in my example of #31 (probably not all undefined behaviors yet). 

The reason for the non-termination was the map lookup here https://github.com/dominikbraun/graph/blob/21fcddafc8008532b8932dd616bda0fbb0e0493d/paths.go#L131 leads to `hashCursor` being set to 0 if the key is not present. Consequently, this leads to endlessly prepending 0 to the path since it will never be equal to the source. 

This is why I added the check whether the key is present and if it is not, an error is returned. Furthermore, I added a test case that is exactly the well-defined example from #31. 

Let me know, if there is something to change.