### PR TITLE
update TopologicalSort to not require PreventCycles and fail if cycle detected

### DIFF
--- a/dag.go
+++ b/dag.go
@@ -12,8 +12,8 @@ import (
 // TopologicalSort only works for directed acyclic graphs. The current implementation works non-
 // recursively and uses Kahn's algorithm.
 func TopologicalSort[K comparable, T any](g Graph[K, T]) ([]K, error) {
-	if !isDAG(g) {
-		return nil, errors.New("topological sort can only be performed on DAGs created with the PreventCycles option")
+	if !g.Traits().IsDirected {
+		return nil, fmt.Errorf("topological sort cannot be computed on undirected graph")
 	}
 
 	predecessorMap, err := g.PredecessorMap()
@@ -50,6 +50,10 @@ func TopologicalSort[K comparable, T any](g Graph[K, T]) ([]K, error) {
 				queue = append(queue, vertex)
 			}
 		}
+	}
+
+	if len(order) != g.Order() {
+		return nil, errors.New("topological sort cannot be computed on graph with cycles")
 	}
 
 	return order, nil

--- a/dag_test.go
+++ b/dag_test.go
@@ -22,7 +22,7 @@ func TestDirectedTopologicalSort(t *testing.T) {
 			},
 			expectedOrder: []int{1, 2, 3, 4, 5},
 		},
-		"graph with cycle vertices": {
+		"graph with cycle": {
 			vertices: []int{1, 2, 3},
 			edges: []Edge[int]{
 				{Source: 1, Target: 2},

--- a/dag_test.go
+++ b/dag_test.go
@@ -48,15 +48,12 @@ func TestDirectedTopologicalSort(t *testing.T) {
 
 		order, err := TopologicalSort(graph)
 
-		if test.shouldFail {
-			if err == nil {
-				t.Fatalf("%s: expected error but got none", name)
-			}
-			continue
+		if test.shouldFail != (err != nil) {
+			t.Errorf("%s: error expectancy doesn't match: expected %v, got %v (error: %v)", name, test.shouldFail, err != nil, err)
 		}
 
-		if err != nil {
-			t.Fatalf("%s: failed to add edge: %s", name, err.Error())
+		if test.shouldFail {
+			continue
 		}
 
 		if len(order) != len(test.expectedOrder) {

--- a/dag_test.go
+++ b/dag_test.go
@@ -7,6 +7,7 @@ func TestDirectedTopologicalSort(t *testing.T) {
 		vertices      []int
 		edges         []Edge[int]
 		expectedOrder []int
+		shouldFail    bool
 	}{
 		"graph with 5 vertices": {
 			vertices: []int{1, 2, 3, 4, 5},
@@ -21,10 +22,19 @@ func TestDirectedTopologicalSort(t *testing.T) {
 			},
 			expectedOrder: []int{1, 2, 3, 4, 5},
 		},
+		"graph with cycle vertices": {
+			vertices: []int{1, 2, 3},
+			edges: []Edge[int]{
+				{Source: 1, Target: 2},
+				{Source: 2, Target: 3},
+				{Source: 3, Target: 1},
+			},
+			shouldFail: true,
+		},
 	}
 
 	for name, test := range tests {
-		graph := New(IntHash, Directed(), PreventCycles())
+		graph := New(IntHash, Directed())
 
 		for _, vertex := range test.vertices {
 			_ = graph.AddVertex(vertex)
@@ -37,6 +47,14 @@ func TestDirectedTopologicalSort(t *testing.T) {
 		}
 
 		order, err := TopologicalSort(graph)
+
+		if test.shouldFail {
+			if err == nil {
+				t.Fatalf("%s: expected error but got none", name)
+			}
+			continue
+		}
+
 		if err != nil {
 			t.Fatalf("%s: failed to add edge: %s", name, err.Error())
 		}


### PR DESCRIPTION
This also adds unit test case for asserting error for graph with cycle.

Fixes: #49 