### PR TITLE
update TransitiveReduction to not mutate given graph and return a new one

### DIFF
--- a/dag.go
+++ b/dag.go
@@ -55,12 +55,10 @@ func TopologicalSort[K comparable, T any](g Graph[K, T]) ([]K, error) {
 	return order, nil
 }
 
-// TransitiveReduction returns another graph with the same vertices and the
-// same reachability, but with as few edges as possible. This greatly reduces
-// the complexity of the graph.
+// TransitiveReduction returns another graph with the same vertices and the same reachability, but
+// with as few edges as possible. This greatly reduces the complexity of the graph.
 //
-// With a time complexity of O(V(V+E)), TransitiveReduction is a very costly
-// operation.
+// With a time complexity of O(V(V+E)), TransitiveReduction is a very costly operation.
 func TransitiveReduction[K comparable, T any](g Graph[K, T]) (Graph[K, T], error) {
 	if !g.Traits().IsDirected {
 		return nil, fmt.Errorf("transitive reduction cannot be performed on undirected graph")
@@ -68,7 +66,7 @@ func TransitiveReduction[K comparable, T any](g Graph[K, T]) (Graph[K, T], error
 
 	transitiveReduction, err := g.Clone()
 	if err != nil {
-		return nil, fmt.Errorf("failed clone the graph: %w", err)
+		return nil, fmt.Errorf("failed to clone the graph: %w", err)
 	}
 
 	adjacencyMap, err := transitiveReduction.AdjacencyMap()
@@ -96,16 +94,16 @@ func TransitiveReduction[K comparable, T any](g Graph[K, T]) (Graph[K, T], error
 				stack = stack[:len(stack)-1]
 
 				if _, ok := visited[current]; !ok {
-					// this node is not yet visited, mark it and put it on stack
+					// If the node is not yet visited, mark it as visited and put it on the stack.
 					visited[current] = struct{}{}
 					onStack[current] = struct{}{}
 				} else {
-					// this node is already visited, remove it from stack
+					// Otherwise, remove the node from the stack.
 					delete(onStack, current)
 					continue
 				}
 
-				// leaf node, remove it from stack
+				// If the node is a leaf node, remove it from the stack.
 				if len(adjacencyMap[current]) == 0 {
 					delete(onStack, current)
 				}
@@ -113,7 +111,7 @@ func TransitiveReduction[K comparable, T any](g Graph[K, T]) (Graph[K, T], error
 				for adjacency := range adjacencyMap[current] {
 					if _, ok := visited[adjacency]; ok {
 						if _, ok := onStack[adjacency]; ok {
-							// if this child is visited as well as on stack, we have a cycle
+							// If this child is visited as well as on the stack, we have a cycle.
 							return nil, fmt.Errorf(
 								"transitive reduction cannot be performed on graph with cycle",
 							)

--- a/dag.go
+++ b/dag.go
@@ -134,7 +134,3 @@ func TransitiveReduction[K comparable, T any](g Graph[K, T]) (Graph[K, T], error
 
 	return transitiveReduction, nil
 }
-
-func isDAG[K comparable, T any](g Graph[K, T]) bool {
-	return g.Traits().IsDirected && g.Traits().PreventCycles
-}

--- a/dag.go
+++ b/dag.go
@@ -55,19 +55,25 @@ func TopologicalSort[K comparable, T any](g Graph[K, T]) ([]K, error) {
 	return order, nil
 }
 
-// TransitiveReduction transforms the graph into its own transitive reduction. The transitive
-// reduction of the given graph is another graph with the same vertices and the same reachability,
-// but with as few edges as possible. This greatly reduces the complexity of the graph.
+// TransitiveReduction returns another graph with the same vertices and the
+// same reachability, but with as few edges as possible. This greatly reduces
+// the complexity of the graph.
 //
-// With a time complexity of O(V(V+E)), TransitiveReduction is a very costly operation.
-func TransitiveReduction[K comparable, T any](g Graph[K, T]) error {
-	if !isDAG(g) {
-		return errors.New("topological sort can only be performed on DAGs created with the PreventCycles option")
+// With a time complexity of O(V(V+E)), TransitiveReduction is a very costly
+// operation.
+func TransitiveReduction[K comparable, T any](g Graph[K, T]) (Graph[K, T], error) {
+	if !g.Traits().IsDirected {
+		return nil, fmt.Errorf("transitive reduction cannot be performed on undirected graph")
 	}
 
-	adjacencyMap, err := g.AdjacencyMap()
+	transitiveReduction, err := g.Clone()
 	if err != nil {
-		return fmt.Errorf("failed to get adajcency map: %w", err)
+		return nil, fmt.Errorf("failed clone the graph: %w", err)
+	}
+
+	adjacencyMap, err := transitiveReduction.AdjacencyMap()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get adajcency map: %w", err)
 	}
 
 	for vertex, successors := range adjacencyMap {
@@ -78,22 +84,53 @@ func TransitiveReduction[K comparable, T any](g Graph[K, T]) error {
 		// These edges are redundant because their targets obviously are reachable via DFS, i.e.
 		// they aren't needed in the top-level vertex anymore and can be removed from there.
 		for successor := range successors {
-			err := DFS(g, successor, func(current K) bool {
-				for _, edge := range adjacencyMap[current] {
-					if _, ok := adjacencyMap[vertex][edge.Target]; ok {
-						_ = g.RemoveEdge(vertex, edge.Target)
-					}
+			visited := make(map[K]struct{}, transitiveReduction.Order())
+			onStack := make(map[K]struct{}, transitiveReduction.Order())
+			stack := append(
+				make([]K, 0, transitiveReduction.Order()),
+				successor,
+			)
+
+			for len(stack) > 0 {
+				current := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+
+				if _, ok := visited[current]; !ok {
+					// this node is not yet visited, mark it and put it on stack
+					visited[current] = struct{}{}
+					onStack[current] = struct{}{}
+				} else {
+					// this node is already visited, remove it from stack
+					delete(onStack, current)
+					continue
 				}
 
-				return false
-			})
-			if err != nil {
-				return err
+				// leaf node, remove it from stack
+				if len(adjacencyMap[current]) == 0 {
+					delete(onStack, current)
+				}
+
+				for adjacency := range adjacencyMap[current] {
+					if _, ok := visited[adjacency]; ok {
+						if _, ok := onStack[adjacency]; ok {
+							// if this child is visited as well as on stack, we have a cycle
+							return nil, fmt.Errorf(
+								"transitive reduction cannot be performed on graph with cycle",
+							)
+						}
+						continue
+					}
+
+					if _, ok := adjacencyMap[vertex][adjacency]; ok {
+						_ = transitiveReduction.RemoveEdge(vertex, adjacency)
+					}
+					stack = append(stack, adjacency)
+				}
 			}
 		}
 	}
 
-	return nil
+	return transitiveReduction, nil
 }
 
 func isDAG[K comparable, T any](g Graph[K, T]) bool {

--- a/dag.go
+++ b/dag.go
@@ -88,26 +88,23 @@ func TransitiveReduction[K comparable, T any](g Graph[K, T]) (Graph[K, T], error
 		for successor := range successors {
 			visited := make(map[K]struct{}, transitiveReduction.Order())
 			onStack := make(map[K]struct{}, transitiveReduction.Order())
-			stack := append(
-				make([]K, 0, transitiveReduction.Order()),
-				successor,
-			)
+			stack := append(make([]K, 0, transitiveReduction.Order()), successor)
 
 			for len(stack) > 0 {
 				current := stack[len(stack)-1]
 				stack = stack[:len(stack)-1]
 
 				if _, ok := visited[current]; !ok {
-					// If the node is not yet visited, mark it as visited and put it on the stack.
+					// If the vertex is not yet visited, mark it as visited and put it on the stack.
 					visited[current] = struct{}{}
 					onStack[current] = struct{}{}
 				} else {
-					// Otherwise, remove the node from the stack.
+					// Otherwise, remove the vertex from the stack.
 					delete(onStack, current)
 					continue
 				}
 
-				// If the node is a leaf node, remove it from the stack.
+				// If the vertex is a leaf node, remove it from the stack.
 				if len(adjacencyMap[current]) == 0 {
 					delete(onStack, current)
 				}
@@ -115,10 +112,8 @@ func TransitiveReduction[K comparable, T any](g Graph[K, T]) (Graph[K, T], error
 				for adjacency := range adjacencyMap[current] {
 					if _, ok := visited[adjacency]; ok {
 						if _, ok := onStack[adjacency]; ok {
-							// If this child is visited as well as on the stack, we have a cycle.
-							return nil, fmt.Errorf(
-								"transitive reduction cannot be performed on graph with cycle",
-							)
+							// If this vertex is visited as well as on the stack, we have a cycle.
+							return nil, fmt.Errorf("transitive reduction cannot be performed on graph with cycle")
 						}
 						continue
 					}

--- a/dag_test.go
+++ b/dag_test.go
@@ -130,7 +130,7 @@ func TestDirectedTransitiveReduction(t *testing.T) {
 			}
 		}
 
-		res, err := TransitiveReduction(graph)
+		reduction, err := TransitiveReduction(graph)
 
 		if test.shouldFail != (err != nil) {
 			t.Errorf("%s: error expectancy doesn't match: expected %v, got %v (error: %v)", name, test.shouldFail, err != nil, err)
@@ -141,7 +141,7 @@ func TestDirectedTransitiveReduction(t *testing.T) {
 		}
 
 		actualEdges := make([]Edge[string], 0)
-		adjacencyMap, _ := res.AdjacencyMap()
+		adjacencyMap, _ := reduction.AdjacencyMap()
 
 		for _, adjacencies := range adjacencyMap {
 			for _, edge := range adjacencies {
@@ -149,7 +149,7 @@ func TestDirectedTransitiveReduction(t *testing.T) {
 			}
 		}
 
-		equalsFunc := res.(*directed[string, string]).edgesAreEqual
+		equalsFunc := reduction.(*directed[string, string]).edgesAreEqual
 
 		if !slicesAreEqualWithFunc(actualEdges, test.expectedEdges, equalsFunc) {
 			t.Errorf("%s: edge expectancy doesn't match: expected %v, got %v", name, test.expectedEdges, actualEdges)


### PR DESCRIPTION
This also:
- removes requirement of `PreventCycles` and fail if a cycle is detected
- adds unit test case for asserting error for graph with cycle.

Fixes: #49 

