### PR TITLE
Add custom data to graph edges

### DIFF
--- a/directed.go
+++ b/directed.go
@@ -160,6 +160,7 @@ func (d *directed[K, T]) AdjacencyMap() (map[K]map[K]Edge[K], error) {
 				Properties: EdgeProperties{
 					Weight:     edge.Properties.Weight,
 					Attributes: edge.Properties.Attributes,
+					Data:       edge.Properties.Data,
 				},
 			}
 		}
@@ -183,6 +184,7 @@ func (d *directed[K, T]) PredecessorMap() (map[K]map[K]Edge[K], error) {
 				Properties: EdgeProperties{
 					Attributes: edge.Properties.Attributes,
 					Weight:     edge.Properties.Weight,
+					Data:       edge.Properties.Data,
 				},
 			}
 		}
@@ -296,6 +298,7 @@ func cloneEdges[K comparable, T any](input map[K]map[K]Edge[T]) map[K]map[K]Edge
 				Properties: EdgeProperties{
 					Attributes: attributes,
 					Weight:     edge.Properties.Weight,
+					Data:       edge.Properties.Data,
 				},
 			}
 		}

--- a/directed_test.go
+++ b/directed_test.go
@@ -234,6 +234,28 @@ func TestDirected_AddEdge(t *testing.T) {
 			},
 			traits: &Traits{},
 		},
+		"edge with data": {
+			vertices: []int{1, 2},
+			edges: []Edge[int]{
+				{
+					Source: 1,
+					Target: 2,
+					Properties: EdgeProperties{
+						Data: "foo",
+					},
+				},
+			},
+			expectedEdges: []Edge[int]{
+				{
+					Source: 1,
+					Target: 2,
+					Properties: EdgeProperties{
+						Data: "foo",
+					},
+				},
+			},
+			traits: &Traits{},
+		},
 	}
 
 	for name, test := range tests {
@@ -247,12 +269,12 @@ func TestDirected_AddEdge(t *testing.T) {
 
 		for _, edge := range test.edges {
 			if len(edge.Properties.Attributes) == 0 {
-				err = graph.AddEdge(edge.Source, edge.Target, EdgeWeight(edge.Properties.Weight))
+				err = graph.AddEdge(edge.Source, edge.Target, EdgeWeight(edge.Properties.Weight), EdgeData(edge.Properties.Data))
 			}
 			// If there are edge attributes, iterate over them and call EdgeAttribute for each
 			// entry. An edge should only have one attribute so that AddEdge is invoked once.
 			for key, value := range edge.Properties.Attributes {
-				err = graph.AddEdge(edge.Source, edge.Target, EdgeWeight(edge.Properties.Weight), EdgeAttribute(key, value))
+				err = graph.AddEdge(edge.Source, edge.Target, EdgeWeight(edge.Properties.Weight), EdgeData(edge.Properties.Data), EdgeAttribute(key, value))
 			}
 			if err != nil {
 				break
@@ -296,6 +318,10 @@ func TestDirected_AddEdge(t *testing.T) {
 				if value != expectedValue {
 					t.Errorf("%s: attribute values don't match: expected value %v for key %v, got %v", name, expectedValue, expectedKey, value)
 				}
+			}
+
+			if edge.Properties.Data != expectedEdge.Properties.Data {
+				t.Errorf("%s: edge data doesn't match: expected data %v, got %v", name, expectedEdge.Properties.Data, edge.Properties.Data)
 			}
 		}
 	}

--- a/graph.go
+++ b/graph.go
@@ -113,6 +113,7 @@ type Edge[T any] struct {
 type EdgeProperties struct {
 	Attributes map[string]string
 	Weight     int
+	Data       any
 }
 
 // Hash is a hashing function that takes a vertex of type T and returns a hash value of type K.
@@ -202,6 +203,14 @@ func EdgeWeight(weight int) func(*EdgeProperties) {
 func EdgeAttribute(key, value string) func(*EdgeProperties) {
 	return func(e *EdgeProperties) {
 		e.Attributes[key] = value
+	}
+}
+
+// EdgeData returns a function that sets the data of an edge to the given value. This is a functional
+// option for the Edge and AddEdge methods.
+func EdgeData(data any) func(*EdgeProperties) {
+	return func(e *EdgeProperties) {
+		e.Data = data
 	}
 }
 

--- a/undirected.go
+++ b/undirected.go
@@ -164,6 +164,7 @@ func (u *undirected[K, T]) AdjacencyMap() (map[K]map[K]Edge[K], error) {
 				Properties: EdgeProperties{
 					Weight:     edge.Properties.Weight,
 					Attributes: edge.Properties.Attributes,
+					Data:       edge.Properties.Data,
 				},
 			}
 		}

--- a/undirected_test.go
+++ b/undirected_test.go
@@ -234,6 +234,28 @@ func TestUndirected_AddEdge(t *testing.T) {
 			},
 			traits: &Traits{},
 		},
+		"edge with data": {
+			vertices: []int{1, 2},
+			edges: []Edge[int]{
+				{
+					Source: 1,
+					Target: 2,
+					Properties: EdgeProperties{
+						Data: "foo",
+					},
+				},
+			},
+			expectedEdges: []Edge[int]{
+				{
+					Source: 1,
+					Target: 2,
+					Properties: EdgeProperties{
+						Data: "foo",
+					},
+				},
+			},
+			traits: &Traits{},
+		},
 	}
 
 	for name, test := range tests {
@@ -247,12 +269,12 @@ func TestUndirected_AddEdge(t *testing.T) {
 
 		for _, edge := range test.edges {
 			if len(edge.Properties.Attributes) == 0 {
-				err = graph.AddEdge(edge.Source, edge.Target, EdgeWeight(edge.Properties.Weight))
+				err = graph.AddEdge(edge.Source, edge.Target, EdgeWeight(edge.Properties.Weight), EdgeData(edge.Properties.Data))
 			}
 			// If there are edge attributes, iterate over them and call EdgeAttribute for each
 			// entry. An edge should only have one attribute so that AddEdge is invoked once.
 			for key, value := range edge.Properties.Attributes {
-				err = graph.AddEdge(edge.Source, edge.Target, EdgeWeight(edge.Properties.Weight), EdgeAttribute(key, value))
+				err = graph.AddEdge(edge.Source, edge.Target, EdgeWeight(edge.Properties.Weight), EdgeData(edge.Properties.Data), EdgeAttribute(key, value))
 			}
 			if err != nil {
 				break
@@ -296,6 +318,10 @@ func TestUndirected_AddEdge(t *testing.T) {
 				if value != expectedValue {
 					t.Errorf("%s: attribute values don't match: expected value %v for key %v, got %v", name, expectedValue, expectedKey, value)
 				}
+			}
+
+			if edge.Properties.Data != expectedEdge.Properties.Data {
+				t.Errorf("%s: edge data doesn't match: expected data %v, got %v", name, expectedEdge.Properties.Data, edge.Properties.Data)
 			}
 		}
 	}


### PR DESCRIPTION
This PR adds a custom data property to `EdgeProperties`. This allows the user to write custom edge data and store it in the graph using the new functional option `EdgeData(data any)`.

My use case for this is creating a DAG for a set of configuration files. These files can import one another in any way (so long as its not circular) and I need a nice way to store information about how to merge these files together on the graph edges.

I tried to find a nice way of adding an edge type to the type constraints in `graph.New()`, but the API didn't seem right and most users probably won't need edge data anyway. Instead, I opted for a simpler (non-API breaking) design that uses a simple `any` interface. Unfortunately, this means the user has to type assert the edge data when pulling it out of the graph. However, I believe this is better than adding a third type constraint and overhauling the API for a feature that most people don't need.