### PR TITLE
feat(#124): full traverse

### DIFF
--- a/dag.go
+++ b/dag.go
@@ -22,13 +22,7 @@ func TopologicalSort[K comparable, T any](g Graph[K, T]) ([]K, error) {
 		return nil, fmt.Errorf("failed to get predecessor map: %w", err)
 	}
 
-	queue := make([]K, 0)
-
-	for vertex, predecessors := range predecessorMap {
-		if len(predecessors) == 0 {
-			queue = append(queue, vertex)
-		}
-	}
+	queue := topologicalEntriesFromPredecessorMap(predecessorMap)
 
 	order := make([]K, 0, len(predecessorMap))
 	visited := make(map[K]struct{})
@@ -63,6 +57,27 @@ func TopologicalSort[K comparable, T any](g Graph[K, T]) ([]K, error) {
 	}
 
 	return order, nil
+}
+
+func TopologicalEntries[K comparable, T any](g Graph[K, T]) ([]K, error) {
+	predecessorMap, err := g.PredecessorMap()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get predecessor map: %w", err)
+	}
+
+	return topologicalEntriesFromPredecessorMap(predecessorMap), nil
+}
+
+func topologicalEntriesFromPredecessorMap[K comparable](predecessorMap map[K]map[K]Edge[K]) []K {
+	queue := make([]K, 0)
+
+	for vertex, predecessors := range predecessorMap {
+		if len(predecessors) == 0 {
+			queue = append(queue, vertex)
+		}
+	}
+
+	return queue
 }
 
 // TransitiveReduction returns a new graph with the same vertices and the same

--- a/dag_test.go
+++ b/dag_test.go
@@ -65,6 +65,14 @@ func TestDirectedTopologicalSort(t *testing.T) {
 				t.Errorf("%s: order expectancy doesn't match: expected %v at %d, got %v", name, expectedVertex, i, order[i])
 			}
 		}
+
+		entries, err := TopologicalEntries(graph)
+		if err != nil {
+			t.Errorf("failed to create topological entries")
+		}
+		if len(entries) == 0 {
+			t.Errorf("topological entries is empty")
+		}
 	}
 }
 

--- a/traversal.go
+++ b/traversal.go
@@ -135,3 +135,18 @@ func BFS[K comparable, T any](g Graph[K, T], start K, visit func(K) bool) error 
 
 	return nil
 }
+
+func FullTraverse[K comparable, T any](g Graph[K, T], visit func(K) bool) error {
+	entries, err := TopologicalEntries(g)
+	if err != nil {
+		return err
+	}
+
+	for _, eachEntry := range entries {
+		err = BFS(g, eachEntry, visit)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/traversal_test.go
+++ b/traversal_test.go
@@ -399,3 +399,72 @@ func TestUndirectedBFS(t *testing.T) {
 		}
 	}
 }
+
+func TestFullTraverse(t *testing.T) {
+	tests := map[string]struct {
+		vertices       []int
+		edges          []Edge[int]
+		startHash      int
+		expectedVisits []int
+		stopAtVertex   int
+	}{
+		"traverse entire graph with 3 vertices": {
+			vertices: []int{1, 2, 3},
+			edges: []Edge[int]{
+				{Source: 1, Target: 2},
+				{Source: 1, Target: 3},
+			},
+			startHash:      1,
+			expectedVisits: []int{1, 2, 3},
+			stopAtVertex:   -1,
+		},
+		"traverse graph with 6 vertices until vertex 4": {
+			vertices: []int{1, 2, 3, 4, 5, 6},
+			edges: []Edge[int]{
+				{Source: 1, Target: 2},
+				{Source: 1, Target: 3},
+				{Source: 2, Target: 4},
+				{Source: 2, Target: 5},
+				{Source: 3, Target: 6},
+			},
+			startHash:      1,
+			expectedVisits: []int{1, 2, 3, 4},
+			stopAtVertex:   4,
+		},
+		"traverse a disconnected graph": {
+			vertices: []int{1, 2, 3, 4},
+			edges: []Edge[int]{
+				{Source: 1, Target: 2},
+				{Source: 3, Target: 4},
+			},
+			startHash:      1,
+			expectedVisits: []int{1, 2},
+			stopAtVertex:   -1,
+		},
+	}
+	for name, test := range tests {
+		graph := New(IntHash, Directed())
+
+		for _, vertex := range test.vertices {
+			_ = graph.AddVertex(vertex)
+		}
+
+		for _, edge := range test.edges {
+			if err := graph.AddEdge(edge.Source, edge.Target); err != nil {
+				t.Fatalf("%s: failed to add edge: %s", name, err.Error())
+			}
+		}
+
+		visited := map[int]struct{}{}
+		err := FullTraverse(graph, func(i int) bool {
+			visited[i] = struct{}{}
+			return false
+		})
+		if err != nil {
+			t.Fatalf("traverse failed")
+		}
+		if len(visited) != len(test.vertices) {
+			t.Fatalf("traversal did not walk all the nodes")
+		}
+	}
+}


### PR DESCRIPTION
Hi :)

This is an implementation (draft) for #124 .

- add `TopologicalEntries` for searching entries
- add `FullTraverse` for walking all the nodes

It already matches my need. However, as a library, there are still some issues that need to be discussed:

- It does not include the semantics of BFS or DFS
- it may end up visiting some nodes multiple times