### PR TITLE
Make StableTopologicalSort sort even less

### DIFF
--- a/dag.go
+++ b/dag.go
@@ -111,6 +111,8 @@ func StableTopologicalSort[K comparable, T any](g Graph[K, T], less func(K, K) b
 		order = append(order, currentVertex)
 		visited[currentVertex] = struct{}{}
 
+		frontier := make([]K, 0)
+
 		for vertex, predecessors := range predecessorMap {
 			delete(predecessors, currentVertex)
 
@@ -122,13 +124,15 @@ func StableTopologicalSort[K comparable, T any](g Graph[K, T], less func(K, K) b
 				continue
 			}
 
-			queue = append(queue, vertex)
+			frontier = append(frontier, vertex)
 			queued[vertex] = struct{}{}
 		}
 
-		sort.Slice(queue, func(i, j int) bool {
-			return less(queue[i], queue[j])
+		sort.Slice(frontier, func(i, j int) bool {
+			return less(frontier[i], frontier[j])
 		})
+
+		queue = append(queue, frontier...)
 	}
 
 	gOrder, err := g.Order()


### PR DESCRIPTION
In order to get deterministic order, we don't actually have to sort the entire queue after every pass, we just have to enqueue in a deterministic order.

This change adds a separate frontier that gets sorted before it gets appended to the queue after each pass.

For what it's worth, this doesn't affect performance in a perceivable way for us, so feel free to reject it, but on the same workload as my last PR, this goes from making 242651 comparisons to only 5106 comparisons, which seems fairly close to optimal.