### PR TITLE
Initialize maps to appropriate sizes

### DIFF
--- a/dag.go
+++ b/dag.go
@@ -22,6 +22,11 @@ func TopologicalSort[K comparable, T any](g Graph[K, T]) ([]K, error) {
 		return nil, fmt.Errorf("topological sort cannot be computed on undirected graph")
 	}
 
+	gOrder, err := g.Order()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get graph order: %w", err)
+	}
+
 	predecessorMap, err := g.PredecessorMap()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get predecessor map: %w", err)
@@ -35,8 +40,8 @@ func TopologicalSort[K comparable, T any](g Graph[K, T]) ([]K, error) {
 		}
 	}
 
-	order := make([]K, 0, len(predecessorMap))
-	visited := make(map[K]struct{})
+	order := make([]K, 0, gOrder)
+	visited := make(map[K]struct{}, gOrder)
 
 	for len(queue) > 0 {
 		currentVertex := queue[0]
@@ -56,11 +61,6 @@ func TopologicalSort[K comparable, T any](g Graph[K, T]) ([]K, error) {
 				queue = append(queue, vertex)
 			}
 		}
-	}
-
-	gOrder, err := g.Order()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get graph order: %w", err)
 	}
 
 	if len(order) != gOrder {

--- a/directed.go
+++ b/directed.go
@@ -198,7 +198,7 @@ func (d *directed[K, T]) AdjacencyMap() (map[K]map[K]Edge[K], error) {
 		return nil, fmt.Errorf("failed to list edges: %w", err)
 	}
 
-	m := make(map[K]map[K]Edge[K])
+	m := make(map[K]map[K]Edge[K], len(vertices))
 
 	for _, vertex := range vertices {
 		m[vertex] = make(map[K]Edge[K])
@@ -212,8 +212,6 @@ func (d *directed[K, T]) AdjacencyMap() (map[K]map[K]Edge[K], error) {
 }
 
 func (d *directed[K, T]) PredecessorMap() (map[K]map[K]Edge[K], error) {
-	m := make(map[K]map[K]Edge[K])
-
 	vertices, err := d.store.ListVertices()
 	if err != nil {
 		return nil, fmt.Errorf("failed to list vertices: %w", err)
@@ -223,6 +221,8 @@ func (d *directed[K, T]) PredecessorMap() (map[K]map[K]Edge[K], error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to list edges: %w", err)
 	}
+
+	m := make(map[K]map[K]Edge[K], len(vertices))
 
 	for _, vertex := range vertices {
 		m[vertex] = make(map[K]Edge[K])

--- a/sets.go
+++ b/sets.go
@@ -70,7 +70,7 @@ type unionFind[K comparable] struct {
 
 func newUnionFind[K comparable](vertices ...K) *unionFind[K] {
 	u := &unionFind[K]{
-		parents: make(map[K]K),
+		parents: make(map[K]K, len(vertices)),
 	}
 
 	for _, vertex := range vertices {

--- a/store.go
+++ b/store.go
@@ -99,7 +99,7 @@ func (s *memoryStore[K, T]) ListVertices() ([]K, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 
-	var hashes []K
+	hashes := make([]K, 0, len(s.vertices))
 	for k := range s.vertices {
 		hashes = append(hashes, k)
 	}

--- a/undirected.go
+++ b/undirected.go
@@ -264,7 +264,7 @@ func (u *undirected[K, T]) AdjacencyMap() (map[K]map[K]Edge[K], error) {
 		return nil, fmt.Errorf("failed to list edges: %w", err)
 	}
 
-	m := make(map[K]map[K]Edge[K])
+	m := make(map[K]map[K]Edge[K], len(vertices))
 
 	for _, vertex := range vertices {
 		m[vertex] = make(map[K]Edge[K])


### PR DESCRIPTION
Found a few places where we were spending a lot of time growing maps and slices.

This change initializes maps and slices in places where it seems to have no downside.