### PR TITLE
feat(#82): List all path between vertices

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -106,3 +106,56 @@ func (m *minHeap[T]) Pop() interface{} {
 
 	return item
 }
+
+type stack[T any] interface {
+	push(T)
+	pop() (T, error)
+	top() (T, error)
+	isEmpty() bool
+	// forEach iterate the stack from bottom to top
+	forEach(func(T))
+}
+
+func newStack[T any]() stack[T] {
+	return &stackImpl[T]{
+		elements: make([]T, 0),
+	}
+}
+
+type stackImpl[T any] struct {
+	elements []T
+}
+
+func (s *stackImpl[T]) push(t T) {
+	s.elements = append(s.elements, t)
+}
+
+func (s *stackImpl[T]) pop() (T, error) {
+	e, err := s.top()
+	if err != nil {
+		var defaultValue T
+		return defaultValue, err
+	}
+
+	s.elements = s.elements[:len(s.elements)-1]
+	return e, nil
+}
+
+func (s *stackImpl[T]) top() (T, error) {
+	if s.isEmpty() {
+		var defaultValue T
+		return defaultValue, errors.New("no element in stack")
+	}
+
+	return s.elements[len(s.elements)-1], nil
+}
+
+func (s *stackImpl[T]) isEmpty() bool {
+	return len(s.elements) == 0
+}
+
+func (s *stackImpl[T]) forEach(f func(T)) {
+	for _, e := range s.elements {
+		f(e)
+	}
+}

--- a/collection_test.go
+++ b/collection_test.go
@@ -222,3 +222,31 @@ func TestPriorityQueue_Len(t *testing.T) {
 		}
 	}
 }
+
+func TestStack(t *testing.T) {
+	s := newStack[int]()
+
+	assert := func(expression bool) {
+		if !expression {
+			t.Fatal()
+		}
+	}
+
+	assert(s.isEmpty())
+
+	s.push(1)
+	assert(!s.isEmpty())
+	e, _ := s.top()
+	assert(e == 1)
+	e, _ = s.pop()
+	assert(e == 1)
+	assert(s.isEmpty())
+
+	s.push(1)
+	s.push(2)
+	s.push(3)
+	e, _ = s.pop()
+	assert(e == 3)
+	e, _ = s.top()
+	assert(e == 2)
+}

--- a/paths.go
+++ b/paths.go
@@ -232,3 +232,104 @@ func findSCC[K comparable](vertexHash K, state *sccState[K]) {
 		state.components = append(state.components, component)
 	}
 }
+
+// AllPathsBetweenTwoVertices list all paths from start to end.
+func AllPathsBetweenTwoVertices[K comparable, T any](g Graph[K, T], start, end K) ([][]K, error) {
+	adjacencyMap, err := g.AdjacencyMap()
+	if err != nil {
+		return nil, err
+	}
+
+	mainStack, viceStack := newStack[K](), newStack[stack[K]]()
+
+	checkEmpty := func() error {
+		if mainStack.isEmpty() || viceStack.isEmpty() {
+			return errors.New("empty stack")
+		}
+		return nil
+	}
+
+	buildLayer := func(element K) {
+		mainStack.push(element)
+
+		newElements := newStack[K]()
+		for e := range adjacencyMap[element] {
+			var contains bool
+			mainStack.forEach(func(k K) {
+				if e == k {
+					contains = true
+				}
+			})
+			if contains {
+				continue
+			}
+			newElements.push(e)
+		}
+		viceStack.push(newElements)
+	}
+
+	buildStack := func() error {
+		if err := checkEmpty(); err != nil {
+			return errors.New("empty stack")
+		}
+
+		elements, _ := viceStack.top()
+		for !elements.isEmpty() {
+			element, _ := elements.pop()
+			buildLayer(element)
+			elements, _ = viceStack.top()
+		}
+
+		return nil
+	}
+
+	removeLayer := func() error {
+		if err := checkEmpty(); err != nil {
+			return errors.New("empty stack")
+		}
+
+		e, _ := viceStack.top()
+		if !e.isEmpty() {
+			return errors.New("the top element of vice-stack is not empty")
+		}
+
+		_, _ = mainStack.pop()
+		_, _ = viceStack.pop()
+
+		return nil
+	}
+
+	// init the first layer
+
+	buildLayer(start)
+
+	// loop
+
+	allPaths := make([][]K, 0)
+
+	for !mainStack.isEmpty() {
+		v, _ := mainStack.top()
+		adjs, _ := viceStack.top()
+
+		if adjs.isEmpty() {
+			if v == end {
+				path := make([]K, 0)
+				mainStack.forEach(func(k K) {
+					path = append(path, k)
+				})
+				allPaths = append(allPaths, path)
+			}
+
+			err = removeLayer()
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			if err = buildStack(); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return allPaths, nil
+}


### PR DESCRIPTION
The algorithm uses 2 stack and a loop to find out all paths between 2 vertices. It could be applied to both directed-graph and undirected-graph.