### PR TITLE
feat(#82): List all path between vertices

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -106,3 +106,56 @@ func (m *minHeap[T]) Pop() interface{} {
 
 	return item
 }
+
+type stack[T any] interface {
+	push(T)
+	pop() (T, error)
+	top() (T, error)
+	isEmpty() bool
+	// forEach iterate the stack from bottom to top
+	forEach(func(T))
+}
+
+func newStack[T any]() stack[T] {
+	return &stackImpl[T]{
+		elements: make([]T, 0),
+	}
+}
+
+type stackImpl[T any] struct {
+	elements []T
+}
+
+func (s *stackImpl[T]) push(t T) {
+	s.elements = append(s.elements, t)
+}
+
+func (s *stackImpl[T]) pop() (T, error) {
+	e, err := s.top()
+	if err != nil {
+		var defaultValue T
+		return defaultValue, err
+	}
+
+	s.elements = s.elements[:len(s.elements)-1]
+	return e, nil
+}
+
+func (s *stackImpl[T]) top() (T, error) {
+	if s.isEmpty() {
+		var defaultValue T
+		return defaultValue, errors.New("no element in stack")
+	}
+
+	return s.elements[len(s.elements)-1], nil
+}
+
+func (s *stackImpl[T]) isEmpty() bool {
+	return len(s.elements) == 0
+}
+
+func (s *stackImpl[T]) forEach(f func(T)) {
+	for _, e := range s.elements {
+		f(e)
+	}
+}

--- a/collection_test.go
+++ b/collection_test.go
@@ -1,6 +1,7 @@
 package graph
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -220,5 +221,169 @@ func TestPriorityQueue_Len(t *testing.T) {
 		if n != test.expectedLen {
 			t.Errorf("%s: length expectancy doesn't match: expected %v, got %v", name, test.expectedLen, n)
 		}
+	}
+}
+
+func Test_stackImpl_push(t *testing.T) {
+	type args[T any] struct {
+		t T
+	}
+	type testCase[T any] struct {
+		name string
+		s    stackImpl[T]
+		args args[T]
+	}
+	tests := []testCase[int]{
+		{
+			"push 1",
+			stackImpl[int]{
+				elements: make([]int, 0),
+			},
+			args[int]{
+				t: 1,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.s.push(tt.args.t)
+		})
+	}
+}
+
+func Test_stackImpl_pop(t *testing.T) {
+	type testCase[T any] struct {
+		name    string
+		s       stackImpl[T]
+		want    T
+		wantErr bool
+	}
+	tests := []testCase[int]{
+		{
+			"pop element",
+			stackImpl[int]{
+				elements: []int{1},
+			},
+			1,
+			false,
+		},
+		{
+			"pop element from empty stack",
+			stackImpl[int]{
+				elements: []int{},
+			},
+			0,
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.s.pop()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("pop() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("pop() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_stackImpl_top(t *testing.T) {
+	type testCase[T any] struct {
+		name    string
+		s       stackImpl[T]
+		want    T
+		wantErr bool
+	}
+	tests := []testCase[int]{
+		{
+			"top element",
+			stackImpl[int]{
+				elements: []int{1},
+			},
+			1,
+			false,
+		},
+		{
+			"top element of empty stack",
+			stackImpl[int]{
+				elements: []int{},
+			},
+			0,
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.s.top()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("top() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("top() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_stackImpl_isEmpty(t *testing.T) {
+	type testCase[T any] struct {
+		name string
+		s    stackImpl[T]
+		want bool
+	}
+	tests := []testCase[int]{
+		{
+			"empty",
+			stackImpl[int]{
+				elements: []int{},
+			},
+			true,
+		},
+		{
+			"not empty",
+			stackImpl[int]{
+				elements: []int{1},
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.s.isEmpty(); got != tt.want {
+				t.Errorf("isEmpty() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_stackImpl_forEach(t *testing.T) {
+	type args[T any] struct {
+		f func(T)
+	}
+	type testCase[T any] struct {
+		name string
+		s    stackImpl[T]
+		args args[T]
+	}
+	tests := []testCase[int]{
+		{
+			name: "forEach",
+			s: stackImpl[int]{
+				elements: []int{1, 2, 3, 4, 5, 6},
+			},
+			args: args[int]{
+				f: func(i int) {
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.s.forEach(tt.args.f)
+		})
 	}
 }

--- a/paths.go
+++ b/paths.go
@@ -233,8 +233,8 @@ func findSCC[K comparable](vertexHash K, state *sccState[K]) {
 	}
 }
 
-// AllPathsBetweenTwoVertices list all paths from start to end.
-func AllPathsBetweenTwoVertices[K comparable, T any](g Graph[K, T], start, end K) ([][]K, error) {
+// AllPathsBetween list all paths from start to end.
+func AllPathsBetween[K comparable, T any](g Graph[K, T], start, end K) ([][]K, error) {
 	adjacencyMap, err := g.AdjacencyMap()
 	if err != nil {
 		return nil, err

--- a/paths_test.go
+++ b/paths_test.go
@@ -499,7 +499,7 @@ func TestUndirectedStronglyConnectedComponents(t *testing.T) {
 	}
 }
 
-func TestAllPathBetweenTwoVertices(t *testing.T) {
+func TestAllPathsBetweenTwoVertices(t *testing.T) {
 	type args[K comparable, T any] struct {
 		g     Graph[K, T]
 		start K

--- a/paths_test.go
+++ b/paths_test.go
@@ -499,7 +499,7 @@ func TestUndirectedStronglyConnectedComponents(t *testing.T) {
 	}
 }
 
-func TestAllPathsBetweenTwoVertices(t *testing.T) {
+func TestAllPathsBetween(t *testing.T) {
 	type args[K comparable, T any] struct {
 		g     Graph[K, T]
 		start K
@@ -626,9 +626,9 @@ func TestAllPathsBetweenTwoVertices(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := AllPathsBetweenTwoVertices(tt.args.g, tt.args.start, tt.args.end)
+			got, err := AllPathsBetween(tt.args.g, tt.args.start, tt.args.end)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("AllPathsBetweenTwoVertices() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("AllPathsBetween() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 
@@ -649,7 +649,7 @@ func TestAllPathsBetweenTwoVertices(t *testing.T) {
 			})
 
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("AllPathsBetweenTwoVertices() got = %v, want %v", got, tt.want)
+				t.Errorf("AllPathsBetween() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/paths_test.go
+++ b/paths_test.go
@@ -1,6 +1,8 @@
 package graph
 
 import (
+	"reflect"
+	"sort"
 	"testing"
 )
 
@@ -494,5 +496,161 @@ func TestUndirectedStronglyConnectedComponents(t *testing.T) {
 		if test.expectedSCCs == nil && sccs != nil {
 			t.Errorf("%s: SCC expectancy doesn't match: expcted %v, got %v", name, test.expectedSCCs, sccs)
 		}
+	}
+}
+
+func TestAllPathBetweenTwoVertices(t *testing.T) {
+	type args[K comparable, T any] struct {
+		g     Graph[K, T]
+		start K
+		end   K
+	}
+	type testCase[K comparable, T any] struct {
+		name    string
+		args    args[K, T]
+		want    [][]K
+		wantErr bool
+	}
+	tests := []testCase[int, int]{
+		{
+			name: "directed",
+			args: args[int, int]{
+				g: func() Graph[int, int] {
+					g := New(IntHash, Directed())
+					for i := 0; i <= 8; i++ {
+						_ = g.AddVertex(i)
+					}
+					_ = g.AddEdge(0, 2)
+					_ = g.AddEdge(1, 0)
+					_ = g.AddEdge(1, 4)
+					_ = g.AddEdge(2, 6)
+					_ = g.AddEdge(3, 1)
+					_ = g.AddEdge(3, 7)
+					_ = g.AddEdge(4, 5)
+					_ = g.AddEdge(5, 2)
+					_ = g.AddEdge(5, 6)
+					_ = g.AddEdge(6, 8)
+					_ = g.AddEdge(7, 4)
+					return g
+				}(),
+				start: 3,
+				end:   6,
+			},
+			want: [][]int{
+				{3, 1, 0, 2, 6},
+				{3, 1, 4, 5, 6},
+				{3, 1, 4, 5, 2, 6},
+				{3, 7, 4, 5, 2, 6},
+				{3, 7, 4, 5, 6},
+			},
+			wantErr: false,
+		},
+		{
+			name: "undirected",
+			args: args[int, int]{
+				g: func() Graph[int, int] {
+					g := New(IntHash)
+					for i := 0; i <= 8; i++ {
+						_ = g.AddVertex(i)
+					}
+					_ = g.AddEdge(0, 1)
+					_ = g.AddEdge(0, 2)
+					_ = g.AddEdge(1, 3)
+					_ = g.AddEdge(1, 4)
+					_ = g.AddEdge(2, 5)
+					_ = g.AddEdge(2, 6)
+					_ = g.AddEdge(3, 7)
+					_ = g.AddEdge(4, 5)
+					_ = g.AddEdge(4, 7)
+					_ = g.AddEdge(5, 6)
+					_ = g.AddEdge(6, 8)
+					return g
+				}(),
+				start: 3,
+				end:   6,
+			},
+			want: [][]int{
+				{3, 1, 0, 2, 6},
+				{3, 1, 0, 2, 5, 6},
+				{3, 1, 4, 5, 6},
+				{3, 1, 4, 5, 2, 6},
+				{3, 7, 4, 5, 2, 6},
+				{3, 7, 4, 5, 6},
+				{3, 7, 4, 1, 0, 2, 6},
+				{3, 7, 4, 1, 0, 2, 5, 6},
+			},
+			wantErr: false,
+		},
+		{
+			name: "undirected (complex)",
+			args: args[int, int]{
+				g: func() Graph[int, int] {
+					g := New(IntHash)
+					for i := 0; i <= 9; i++ {
+						_ = g.AddVertex(i)
+					}
+					_ = g.AddEdge(0, 1)
+					_ = g.AddEdge(0, 2)
+					_ = g.AddEdge(0, 3)
+					_ = g.AddEdge(2, 3)
+					_ = g.AddEdge(2, 6)
+					_ = g.AddEdge(3, 4)
+					_ = g.AddEdge(4, 8)
+					_ = g.AddEdge(5, 6)
+					_ = g.AddEdge(5, 8)
+					_ = g.AddEdge(5, 9)
+					_ = g.AddEdge(6, 7)
+					_ = g.AddEdge(7, 9)
+					_ = g.AddEdge(8, 9)
+					return g
+				}(),
+				start: 0,
+				end:   9,
+			},
+			want: [][]int{
+				{0, 2, 3, 4, 8, 5, 6, 7, 9},
+				{0, 2, 3, 4, 8, 5, 9},
+				{0, 2, 3, 4, 8, 9},
+				{0, 2, 6, 5, 8, 9},
+				{0, 2, 6, 5, 9},
+				{0, 2, 6, 7, 9},
+				{0, 3, 2, 6, 5, 8, 9},
+				{0, 3, 2, 6, 5, 9},
+				{0, 3, 2, 6, 7, 9},
+				{0, 3, 4, 8, 5, 6, 7, 9},
+				{0, 3, 4, 8, 5, 9},
+				{0, 3, 4, 8, 9},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := AllPathsBetweenTwoVertices(tt.args.g, tt.args.start, tt.args.end)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AllPathsBetweenTwoVertices() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			toStr := func(s []int) string {
+				var num string
+				for _, n := range s {
+					num = num + string(rune(n))
+				}
+				return num
+			}
+
+			sort.Slice(got, func(i, j int) bool {
+				return toStr(got[i]) < toStr(got[j])
+			})
+
+			sort.Slice(tt.want, func(i, j int) bool {
+				return toStr(tt.want[i]) < toStr(tt.want[j])
+			})
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("AllPathsBetweenTwoVertices() got = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
The algorithm uses 2 stack and a loop to find out all paths between 2 vertices. It could be applied to both directed-graph and undirected-graph.