### PR TITLE
normalize edges to use Edge[K] rather than both Edge[K] and Edge[T], …

### DIFF
--- a/directed.go
+++ b/directed.go
@@ -131,25 +131,15 @@ func (d *directed[K, T]) AddEdgesFrom(g Graph[K, T]) error {
 	return nil
 }
 
-func (d *directed[K, T]) Edge(sourceHash, targetHash K) (Edge[T], error) {
+func (d *directed[K, T]) Edge(sourceHash, targetHash K) (Edge[K], error) {
 	edge, err := d.store.Edge(sourceHash, targetHash)
 	if err != nil {
-		return Edge[T]{}, err
+		return Edge[K]{}, err
 	}
 
-	sourceVertex, _, err := d.store.Vertex(sourceHash)
-	if err != nil {
-		return Edge[T]{}, err
-	}
-
-	targetVertex, _, err := d.store.Vertex(targetHash)
-	if err != nil {
-		return Edge[T]{}, err
-	}
-
-	return Edge[T]{
-		Source: sourceVertex,
-		Target: targetVertex,
+	return Edge[K]{
+		Source: sourceHash,
+		Target: targetHash,
 		Properties: EdgeProperties{
 			Weight:     edge.Properties.Weight,
 			Attributes: edge.Properties.Attributes,
@@ -286,13 +276,10 @@ func (d *directed[K, T]) Size() (int, error) {
 	return size, nil
 }
 
-func (d *directed[K, T]) edgesAreEqual(a, b Edge[T]) bool {
-	aSourceHash := d.hash(a.Source)
-	aTargetHash := d.hash(a.Target)
-	bSourceHash := d.hash(b.Source)
-	bTargetHash := d.hash(b.Target)
-
-	return aSourceHash == bSourceHash && aTargetHash == bTargetHash
+// This only tells you the source and target are the same, it does not
+// tell you that the edge properties are the same as well.
+func (d *directed[K, T]) edgesAreEqual(a, b Edge[K]) bool {
+	return a.Source == b.Source && a.Target == b.Target
 }
 
 func (d *directed[K, T]) createsCycle(source, target K) (bool, error) {

--- a/graph.go
+++ b/graph.go
@@ -124,7 +124,7 @@ type Graph[K comparable, T any] interface {
 	// Edge returns the edge joining two given vertices or ErrEdgeNotFound if
 	// the edge doesn't exist. In an undirected graph, an edge with swapped
 	// source and target vertices does match.
-	Edge(sourceHash, targetHash K) (Edge[T], error)
+	Edge(sourceHash, targetHash K) (Edge[K], error)
 
 	// Edges returns a slice of all edges in the graph. These edges are of type
 	// Edge[K] and hence will contain the vertex hashes, not the vertex values.
@@ -213,9 +213,9 @@ type Graph[K comparable, T any] interface {
 // Edge represents an edge that joins two vertices. Even though these edges are
 // always referred to as source and target, whether the graph is directed or not
 // is determined by its traits.
-type Edge[T any] struct {
-	Source     T
-	Target     T
+type Edge[K comparable] struct {
+	Source     K
+	Target     K
 	Properties EdgeProperties
 }
 
@@ -230,6 +230,21 @@ type EdgeProperties struct {
 	Attributes map[string]string
 	Weight     int
 	Data       any
+}
+
+func (p *EdgeProperties) Clone() EdgeProperties {
+
+	ep := EdgeProperties{
+		Attributes: make(map[string]string),
+		Weight:     p.Weight,
+		Data:       p.Data,
+	}
+
+	for k, v := range p.Attributes {
+		ep.Attributes[k] = v
+	}
+
+	return ep
 }
 
 // Hash is a hashing function that takes a vertex of type T and returns a hash

--- a/undirected_test.go
+++ b/undirected_test.go
@@ -384,11 +384,8 @@ func TestUndirected_AddEdge(t *testing.T) {
 		}
 
 		for _, expectedEdge := range test.expectedEdges {
-			sourceHash := graph.hash(expectedEdge.Source)
-			targetHash := graph.hash(expectedEdge.Target)
-
-			edge, ok := graph.store.(*memoryStore[int, int]).outEdges[sourceHash][targetHash]
-			if !ok {
+			edge, err := graph.Edge(expectedEdge.Source, expectedEdge.Target)
+			if err != nil {
 				t.Fatalf("%s: edge with source %v and target %v not found", name, expectedEdge.Source, expectedEdge.Target)
 			}
 


### PR DESCRIPTION
…also addressed storing duplicate edge properties within the memory store which addresses issue #110.

Currently the codebase seems to be a bit fragmented, in that there are many instances where edges are defined using Edge[K] and others using Edge[T].  While this isn't necessarily a big deal when K and T are the same type, it can become an issue when they're not.  I opted to go with Edge[K] instead of Edge[T], because I figured it would be easier to guarantee the references / pointers were correct using the keys/hashes than with the vertices directly when passing them from the store to the graph.  That said, if you think Edge[T] is the better choice I'd be interested to hear your ideas on how to handle that.

It should be noted, if it isn't already obvious that this will likely be a breaking change for some users of the library.