### PR TITLE
added Vertices() to Graph interface

### DIFF
--- a/directed.go
+++ b/directed.go
@@ -62,6 +62,10 @@ func (d *directed[K, T]) Vertex(hash K) (T, error) {
 	return vertex, err
 }
 
+func (d *directed[K, T]) Vertices() ([]K, error) {
+	return d.store.ListVertices()
+}
+
 func (d *directed[K, T]) VertexWithProperties(hash K) (T, VertexProperties, error) {
 	vertex, properties, err := d.store.Vertex(hash)
 	if err != nil {

--- a/graph.go
+++ b/graph.go
@@ -88,6 +88,10 @@ type Graph[K comparable, T any] interface {
 	// doesn't exist.
 	Vertex(hash K) (T, error)
 
+	// Vertices returns a slice of all vertices in the graph. These vertices are of type
+	// Vertice[K] and hence will contain the vertex hashes, not the vertex values.
+	Vertices() ([]K, error)
+
 	// VertexWithProperties returns the vertex with the given hash along with
 	// its properties or ErrVertexNotFound if it doesn't exist.
 	VertexWithProperties(hash K) (T, VertexProperties, error)

--- a/undirected.go
+++ b/undirected.go
@@ -43,6 +43,10 @@ func (u *undirected[K, T]) Vertex(hash K) (T, error) {
 	return vertex, err
 }
 
+func (u *undirected[K, T]) Vertices() ([]K, error) {
+	return u.store.ListVertices()
+}
+
 func (u *undirected[K, T]) VertexWithProperties(hash K) (T, VertexProperties, error) {
 	vertex, prop, err := u.store.Vertex(hash)
 	if err != nil {


### PR DESCRIPTION
This is a proposed solution to #130.  Alternatively I could see renaming this to ListVertices() and adding a Vertices() that returns the actual vertices, though that might be more challenging since there is currently no Vertex type so conveying the VertexProperties would not happen as it does with Edges() and their corresponding EdgeProperties.

Building on the earlier idea, it might be beneficial to introduce a Vertex type:

```go
type Vertex[T any] struct {
    Value T
    Properties VertexProperties
}
```

Then this would enable the ability to create a Vertices() like this:

```go
func Vertices() ([]Vertex[T], error)
```