### PR TITLE
Add error structs to give more information on errors

### DIFF
--- a/directed.go
+++ b/directed.go
@@ -82,7 +82,7 @@ func (d *directed[K, T]) AddEdge(sourceHash, targetHash K, options ...func(*Edge
 			return fmt.Errorf("check for cycles: %w", err)
 		}
 		if createsCycle {
-			return ErrEdgeCreatesCycle
+			return &EdgeCausesCycleError[K]{Source: sourceHash, Target: targetHash}
 		}
 	}
 

--- a/directed_test.go
+++ b/directed_test.go
@@ -886,7 +886,7 @@ func TestDirected_RemoveEdge(t *testing.T) {
 			removeEdges: []Edge[int]{
 				{Source: 2, Target: 3},
 			},
-			expectedError: ErrEdgeNotFound,
+			// Expect no error because memoryStore doesn't error
 		},
 	}
 
@@ -909,7 +909,7 @@ func TestDirected_RemoveEdge(t *testing.T) {
 			}
 			// After removing the edge, verify that it can't be retrieved using
 			// Edge anymore.
-			if _, err := graph.Edge(removeEdge.Source, removeEdge.Target); err != ErrEdgeNotFound {
+			if _, err := graph.Edge(removeEdge.Source, removeEdge.Target); !errors.Is(err, ErrEdgeNotFound) {
 				t.Fatalf("%s: error expectancy doesn't match: expected %v, got %v", name, ErrEdgeNotFound, err)
 			}
 		}

--- a/errors.go
+++ b/errors.go
@@ -23,9 +23,13 @@ type (
 		Source, Target K
 	}
 
-	VertexHasEdges[K comparable] struct {
+	VertexHasEdgesError[K comparable] struct {
 		Key   K
 		Count int
+	}
+
+	EdgeCausesCycleError[K comparable] struct {
+		Source, Target K
 	}
 )
 
@@ -45,8 +49,12 @@ func (e *EdgeNotFoundError[K]) Error() string {
 	return fmt.Sprintf("edge %v - %v not found", e.Source, e.Target)
 }
 
-func (e *VertexHasEdges[K]) Error() string {
+func (e *VertexHasEdgesError[K]) Error() string {
 	return fmt.Sprintf("vertex %v has %d edges", e.Key, e.Count)
+}
+
+func (e *EdgeCausesCycleError[K]) Error() string {
+	return fmt.Sprintf("edge %v - %v would cause a cycle", e.Source, e.Target)
 }
 
 var (
@@ -62,4 +70,5 @@ func (e *VertexAlreadyExistsError[K, T]) Unwrap() error { return ErrVertexAlread
 func (e *VertexNotFoundError[K]) Unwrap() error         { return ErrVertexNotFound }
 func (e *EdgeAlreadyExistsError[K]) Unwrap() error      { return ErrEdgeAlreadyExists }
 func (e *EdgeNotFoundError[K]) Unwrap() error           { return ErrEdgeNotFound }
-func (e *VertexHasEdges[K]) Unwrap() error              { return ErrVertexHasEdges }
+func (e *VertexHasEdgesError[K]) Unwrap() error         { return ErrVertexHasEdges }
+func (e *EdgeCausesCycleError[K]) Unwrap() error        { return ErrEdgeCreatesCycle }

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,65 @@
+package graph
+
+import (
+	"errors"
+	"fmt"
+)
+
+type (
+	VertexAlreadyExistsError[K comparable, T any] struct {
+		Key           K
+		ExistingValue T
+	}
+
+	VertexNotFoundError[K comparable] struct {
+		Key K
+	}
+
+	EdgeAlreadyExistsError[K comparable] struct {
+		Source, Target K
+	}
+
+	EdgeNotFoundError[K comparable] struct {
+		Source, Target K
+	}
+
+	VertexHasEdges[K comparable] struct {
+		Key   K
+		Count int
+	}
+)
+
+func (e *VertexAlreadyExistsError[K, T]) Error() string {
+	return fmt.Sprintf("vertex %v already exists with value %v", e.Key, e.ExistingValue)
+}
+
+func (e *VertexNotFoundError[K]) Error() string {
+	return fmt.Sprintf("vertex %v not found", e.Key)
+}
+
+func (e *EdgeAlreadyExistsError[K]) Error() string {
+	return fmt.Sprintf("edge %v - %v already exists", e.Source, e.Target)
+}
+
+func (e *EdgeNotFoundError[K]) Error() string {
+	return fmt.Sprintf("edge %v - %v not found", e.Source, e.Target)
+}
+
+func (e *VertexHasEdges[K]) Error() string {
+	return fmt.Sprintf("vertex %v has %d edges", e.Key, e.Count)
+}
+
+var (
+	ErrVertexNotFound      = errors.New("vertex not found")
+	ErrVertexAlreadyExists = errors.New("vertex already exists")
+	ErrEdgeNotFound        = errors.New("edge not found")
+	ErrEdgeAlreadyExists   = errors.New("edge already exists")
+	ErrEdgeCreatesCycle    = errors.New("edge would create a cycle")
+	ErrVertexHasEdges      = errors.New("vertex has edges")
+)
+
+func (e *VertexAlreadyExistsError[K, T]) Unwrap() error { return ErrVertexAlreadyExists }
+func (e *VertexNotFoundError[K]) Unwrap() error         { return ErrVertexNotFound }
+func (e *EdgeAlreadyExistsError[K]) Unwrap() error      { return ErrEdgeAlreadyExists }
+func (e *EdgeNotFoundError[K]) Unwrap() error           { return ErrEdgeNotFound }
+func (e *VertexHasEdges[K]) Unwrap() error              { return ErrVertexHasEdges }

--- a/graph.go
+++ b/graph.go
@@ -49,17 +49,6 @@
 // For detailed usage examples, take a look at the README.
 package graph
 
-import "errors"
-
-var (
-	ErrVertexNotFound      = errors.New("vertex not found")
-	ErrVertexAlreadyExists = errors.New("vertex already exists")
-	ErrEdgeNotFound        = errors.New("edge not found")
-	ErrEdgeAlreadyExists   = errors.New("edge already exists")
-	ErrEdgeCreatesCycle    = errors.New("edge would create a cycle")
-	ErrVertexHasEdges      = errors.New("vertex has edges")
-)
-
 // Graph represents a generic graph data structure consisting of vertices of
 // type T identified by a hash of type K.
 type Graph[K comparable, T any] interface {

--- a/paths.go
+++ b/paths.go
@@ -15,11 +15,11 @@ var ErrTargetNotReachable = errors.New("target vertex not reachable from source"
 // of the source vertex. In order to determine this, CreatesCycle runs a DFS.
 func CreatesCycle[K comparable, T any](g Graph[K, T], source, target K) (bool, error) {
 	if _, err := g.Vertex(source); err != nil {
-		return false, fmt.Errorf("could not get vertex with hash %v: %w", source, err)
+		return false, fmt.Errorf("could not get source vertex: %w", err)
 	}
 
 	if _, err := g.Vertex(target); err != nil {
-		return false, fmt.Errorf("could not get vertex with hash %v: %w", target, err)
+		return false, fmt.Errorf("could not get target vertex: %w", err)
 	}
 
 	if source == target {

--- a/store.go
+++ b/store.go
@@ -1,6 +1,7 @@
 package graph
 
 import (
+	"fmt"
 	"sync"
 )
 
@@ -260,11 +261,11 @@ func (s *memoryStore[K, T]) CreatesCycle(source, target K) (bool, error) {
 	defer s.lock.RUnlock()
 
 	if _, _, err := s.vertexWithLock(source); err != nil {
-		return false, &VertexNotFoundError[K]{Key: source}
+		return false, fmt.Errorf("could not get source vertex: %w", &VertexNotFoundError[K]{Key: source})
 	}
 
 	if _, _, err := s.vertexWithLock(target); err != nil {
-		return false, &VertexNotFoundError[K]{Key: target}
+		return false, fmt.Errorf("could not get target vertex: %w", &VertexNotFoundError[K]{Key: target})
 	}
 
 	if source == target {

--- a/undirected.go
+++ b/undirected.go
@@ -64,7 +64,7 @@ func (u *undirected[K, T]) AddEdge(sourceHash, targetHash K, options ...func(*Ed
 			return fmt.Errorf("check for cycles: %w", err)
 		}
 		if createsCycle {
-			return ErrEdgeCreatesCycle
+			return &EdgeCausesCycleError[K]{Source: sourceHash, Target: targetHash}
 		}
 	}
 

--- a/undirected_test.go
+++ b/undirected_test.go
@@ -77,7 +77,7 @@ func TestUndirected_AddVertex(t *testing.T) {
 			}
 		}
 
-		if err != test.finallyExpectedError {
+		if !errors.Is(err, test.finallyExpectedError) {
 			t.Errorf("%s: error expectancy doesn't match: expected %v, got %v", name, test.finallyExpectedError, err)
 		}
 
@@ -238,7 +238,7 @@ func TestUndirected_Vertex(t *testing.T) {
 
 		vertex, err := graph.Vertex(test.vertex)
 
-		if err != test.expectedError {
+		if !errors.Is(err, test.expectedError) {
 			t.Errorf("%s: error expectancy doesn't match: expected %v, got %v", name, test.expectedError, err)
 		}
 
@@ -880,7 +880,7 @@ func TestUndirected_RemoveEdge(t *testing.T) {
 			removeEdges: []Edge[int]{
 				{Source: 2, Target: 3},
 			},
-			expectedError: ErrEdgeNotFound,
+			// Expect no error because memoryStore doesn't error
 		},
 	}
 
@@ -903,7 +903,7 @@ func TestUndirected_RemoveEdge(t *testing.T) {
 			}
 			// After removing the edge, verify that it can't be retrieved using
 			// Edge anymore.
-			if _, err := graph.Edge(removeEdge.Source, removeEdge.Target); err != ErrEdgeNotFound {
+			if _, err := graph.Edge(removeEdge.Source, removeEdge.Target); !errors.Is(err, ErrEdgeNotFound) {
 				t.Fatalf("%s: error expectancy doesn't match: expected %v, got %v", name, ErrEdgeNotFound, err)
 			}
 		}
@@ -1284,6 +1284,8 @@ func TestUndirected_addEdge(t *testing.T) {
 		graph := newUndirected(IntHash, &Traits{}, newMemoryStore[int, int]())
 
 		for _, edge := range test.edges {
+			_ = graph.AddVertex(edge.Source)
+			_ = graph.AddVertex(edge.Target)
 			sourceHash := graph.hash(edge.Source)
 			TargetHash := graph.hash(edge.Target)
 			err := graph.addEdge(sourceHash, TargetHash, edge)


### PR DESCRIPTION
Adds the following error structs:
- `VertexAlreadyExistsError[K, T]`
- `VertexNotFoundError[K]`
- `EdgeAlreadyExistsError[K]`
- `EdgeNotFoundError[K]`
- `VertexHasEdges[K]`
- `EdgeCausesCycleError[K]`

This **may be breaking** if users check `err ==` instead of `errors.Is` for specific errors (such as `err == ErrVertexNotFound` and not `errors.Is(err, ErrVertexNotFound)`. Depending on versioning strategy and definition of a breaking change, this may warrant a new major version.

This change also fixes a few issues I found in memoryStore:
- `AddEdge` did not conform to the `Store` interface: "If either vertex doesn't exit, ErrVertexNotFound should be returned for the respective vertex"
- `UpdateEdge` had a data race in which the edge could have changed between the `s.Edge` call and the setting of the edges due to not holding onto the lock.
- `CreatesCycle` was not read locking before accessing `s.inEdges`

To let the store handle error cases when it is part of its interface definition, `undirected` and `directed`:
- `AddEdge` don't check the vertices for existence
- `RemoveEdge` don't check edge existence

And a few minor changes I made while I was there:
- Use `ListEdges` instead of `AdjacencyMap` for `Size`, saves some allocations and another pass through the edges to create the map
- `undirected` copy `directed`'s `createsCycle` method to delegate to the store's version for a more performant implementation