### PR TITLE
Fix potential panic on AdjacencyMap

### DIFF
--- a/directed.go
+++ b/directed.go
@@ -205,6 +205,9 @@ func (d *directed[K, T]) AdjacencyMap() (map[K]map[K]Edge[K], error) {
 	}
 
 	for _, edge := range edges {
+		if _, ok := m[edge.Source]; !ok {
+			return nil, fmt.Errorf("unknown source vertex in edge: %v", edge.Source)
+		}
 		m[edge.Source][edge.Target] = edge
 	}
 


### PR DESCRIPTION
Because the store could theoretically be updated without the use of the
main `AddVertex` and `AddEdge` APIs (which does some input validation),
calculating the `AdjencyMap` could provoke an "assignment to entry in
nil map" panic if the store reported edges that were between unknown
vertices.

Since the edges are always between known vertices, it is an error to try
and match a missing source vertex from the vertex set. If that happens,
it is a data desynchronization error that we report to the user.

In order to test this pathological case, we needed to modify the test to
use the store directly because the "front-facing" API would not allow us
to add Edges on missing vertex.

fixes #102

Signed-off-by: davidovich <david.genest@gmail.com>