### PR TITLE
feat: add method that returns all vertices

### DIFF
--- a/directed.go
+++ b/directed.go
@@ -75,6 +75,10 @@ func (d *directed[K, T]) RemoveVertex(hash K) error {
 	return d.store.RemoveVertex(hash)
 }
 
+func (d *directed[K, T]) Vertices() map[K]T {
+	return d.store.AllVertices()
+}
+
 func (d *directed[K, T]) AddEdge(sourceHash, targetHash K, options ...func(*EdgeProperties)) error {
 	_, _, err := d.store.Vertex(sourceHash)
 	if err != nil {

--- a/graph.go
+++ b/graph.go
@@ -99,6 +99,9 @@ type Graph[K comparable, T any] interface {
 	// be returned. If the vertex doesn't exist, ErrVertexNotFound is returned.
 	RemoveVertex(hash K) error
 
+	// Vertices returns a copy of all vertices as map
+	Vertices() map[K]T
+
 	// AddEdge creates an edge between the source and the target vertex.
 	//
 	// If either vertex cannot be found, ErrVertexNotFound will be returned. If

--- a/undirected.go
+++ b/undirected.go
@@ -56,6 +56,10 @@ func (u *undirected[K, T]) RemoveVertex(hash K) error {
 	return u.store.RemoveVertex(hash)
 }
 
+func (u *undirected[K, T]) Vertices() map[K]T {
+	return u.store.AllVertices()
+}
+
 func (u *undirected[K, T]) AddEdge(sourceHash, targetHash K, options ...func(*EdgeProperties)) error {
 	if _, _, err := u.store.Vertex(sourceHash); err != nil {
 		return fmt.Errorf("could not find source vertex with hash %v: %w", sourceHash, err)


### PR DESCRIPTION
Hi Dominik,

I would like to add a method to Graph and Store interface that returns all the vertices that have been added. I'm using graph to resolve dependencies and have to loop over all the vertices after all the edges have been set without error. So this would safe me from keeping an extra map or slice with vertices in my project. Let me know if you want me to change anything in this implementation. 

Best,
Dominik 