### PR TITLE
 fix: update the Attributes map, instead of using the map provided by the user, preventing two maps from actually being the  same reference (issue #177)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.18.x', '1.19.x', '1.20.x', '1.21.x' ]
+        go: [ '1.18.x', '1.19.x', '1.20.x', '1.21.x', '1.22.x' ]
     steps:
       - name: Set up Go ${{ matrix.go }}
         uses: actions/setup-go@v4
@@ -26,9 +26,9 @@ jobs:
           go get -v -t -d ./...
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.51.2
+          version: v1.58
 
       - name: Test
         run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...

--- a/graph.go
+++ b/graph.go
@@ -335,7 +335,9 @@ func EdgeAttribute(key, value string) func(*EdgeProperties) {
 // [graph.Graph.UpdateEdge] methods.
 func EdgeAttributes(attributes map[string]string) func(*EdgeProperties) {
 	return func(e *EdgeProperties) {
-		e.Attributes = attributes
+		for k, v := range attributes {
+			e.Attributes[k] = v
+		}
 	}
 }
 
@@ -382,6 +384,8 @@ func VertexAttribute(key, value string) func(*VertexProperties) {
 // of a vertex. This is a functional option for the [graph.Graph.AddVertex] methods.
 func VertexAttributes(attributes map[string]string) func(*VertexProperties) {
 	return func(e *VertexProperties) {
-		e.Attributes = attributes
+		for k, v := range attributes {
+			e.Attributes[k] = v
+		}
 	}
 }


### PR DESCRIPTION
In issue https://github.com/dominikbraun/graph/issues/177, every new `Vertex` will contain the same map declared in `redVertexAttr`, which causes the unexcepted behaviour in the issue.
